### PR TITLE
Decrease YaruSimpleDialog close button splashRadius

### DIFF
--- a/lib/src/yaru_simple_dialog.dart
+++ b/lib/src/yaru_simple_dialog.dart
@@ -62,7 +62,7 @@ class YaruSimpleDialog extends StatelessWidget {
           IconButton(
               visualDensity: VisualDensity.compact,
               onPressed: () => Navigator.pop(context),
-              splashRadius: 24,
+              splashRadius: 16,
               icon: Icon(closeIconData))
         ],
       ),


### PR DESCRIPTION
Decrease YaruSimpleDialog close button `splashRadius` to 16.

![Capture d’écran du 2022-01-01 22-15-05](https://user-images.githubusercontent.com/36476595/147860320-99426f9b-bae3-496a-9d96-38a10c29856f.png)

Closes #32 