### PR TITLE
Fixes for scrollable content

### DIFF
--- a/example/lib/widgets/yaru_option_card_list.dart
+++ b/example/lib/widgets/yaru_option_card_list.dart
@@ -9,26 +9,30 @@ class YaruOptionCardList extends StatelessWidget {
   Widget build(BuildContext context) {
     return Row(
       children: [
-        SizedBox(
-          width: 300,
-          height: 300,
-          child: YaruOptionCard(
-            titleText: 'YaruOptionCard 1',
-            bodyText: 'Description...',
-            selected: true,
-            onSelected: () {},
-            okIconData: YaruIcons.camera_photo,
+        Expanded(
+          child: SizedBox(
+            width: 300,
+            height: 300,
+            child: YaruOptionCard(
+              titleText: 'YaruOptionCard 1',
+              bodyText: 'Description...',
+              selected: true,
+              onSelected: () {},
+              okIconData: YaruIcons.camera_photo,
+            ),
           ),
         ),
-        SizedBox(
-          width: 300,
-          height: 300,
-          child: YaruOptionCard(
-            titleText: 'YaruOptionCard 2',
-            bodyText: 'Description...',
-            selected: true,
-            onSelected: () {},
-            okIconData: YaruIcons.camera_photo,
+        Expanded(
+          child: SizedBox(
+            width: 300,
+            height: 300,
+            child: YaruOptionCard(
+              titleText: 'YaruOptionCard 2',
+              bodyText: 'Description...',
+              selected: true,
+              onSelected: () {},
+              okIconData: YaruIcons.camera_photo,
+            ),
           ),
         ),
       ],

--- a/example/lib/yaru_home.dart
+++ b/example/lib/yaru_home.dart
@@ -107,6 +107,7 @@ class _YaruHomeState extends State<YaruHome> {
         ),
       ),
       YaruPageItem(
+        wrapInScrollView: true,
         title: 'YaruRow',
         iconData: YaruIcons.emote_cool,
         builder: (_) => YaruRowList(),
@@ -233,8 +234,13 @@ class _YaruHomeState extends State<YaruHome> {
       YaruPageItem(
           title: 'YaruTabbedPage',
           builder: (_) => Center(
-                child: YaruTabbedPage(width: 1000, height: 500, views: [
-                  Text('Addon'),
+                child: YaruTabbedPage(views: [
+                  SingleChildScrollView(
+                    child: TextField(
+                      maxLines: 100,
+                      // expands: true,
+                    ),
+                  ),
                   Text('accessibility'),
                   Text('Audio'),
                   Text('AddressBook'),

--- a/example/lib/yaru_home.dart
+++ b/example/lib/yaru_home.dart
@@ -126,22 +126,62 @@ class _YaruHomeState extends State<YaruHome> {
       YaruPageItem(
         title: 'YaruSection',
         iconData: YaruIcons.emote_glasses,
-        builder: (_) => YaruSection(
-          headline: 'Headline',
-          headerWidget: SizedBox(
-            child: CircularProgressIndicator(),
-            height: 20,
-            width: 20,
+        builder: (_) => YaruPage(
+          child: Column(
+            children: [
+              YaruSection(
+                headline: 'Headline',
+                headerWidget: SizedBox(
+                  child: CircularProgressIndicator(),
+                  height: 20,
+                  width: 20,
+                ),
+                children: [
+                  YaruRow(
+                    enabled: true,
+                    trailingWidget: Text("Trailing Widget"),
+                    actionWidget: Text("Action Widget"),
+                    description: "Description",
+                  ),
+                ],
+                width: 300,
+              ),
+              YaruSection(
+                headline: 'Headline',
+                headerWidget: SizedBox(
+                  child: CircularProgressIndicator(),
+                  height: 20,
+                  width: 20,
+                ),
+                children: [
+                  YaruRow(
+                    enabled: true,
+                    trailingWidget: Text("Trailing Widget"),
+                    actionWidget: Text("Action Widget"),
+                    description: "Description",
+                  ),
+                ],
+                width: 300,
+              ),
+              YaruSection(
+                headline: 'Headline',
+                headerWidget: SizedBox(
+                  child: CircularProgressIndicator(),
+                  height: 20,
+                  width: 20,
+                ),
+                children: [
+                  YaruRow(
+                    enabled: true,
+                    trailingWidget: Text("Trailing Widget"),
+                    actionWidget: Text("Action Widget"),
+                    description: "Description",
+                  ),
+                ],
+                width: 300,
+              )
+            ],
           ),
-          children: [
-            YaruRow(
-              enabled: true,
-              trailingWidget: Text("Trailing Widget"),
-              actionWidget: Text("Action Widget"),
-              description: "Description",
-            ),
-          ],
-          width: 300,
         ),
       ),
       YaruPageItem(

--- a/example/lib/yaru_home.dart
+++ b/example/lib/yaru_home.dart
@@ -107,7 +107,6 @@ class _YaruHomeState extends State<YaruHome> {
         ),
       ),
       YaruPageItem(
-        wrapInScrollView: true,
         title: 'YaruRow',
         iconData: YaruIcons.emote_cool,
         builder: (_) => YaruRowList(),
@@ -235,10 +234,9 @@ class _YaruHomeState extends State<YaruHome> {
           title: 'YaruTabbedPage',
           builder: (_) => Center(
                 child: YaruTabbedPage(views: [
-                  SingleChildScrollView(
+                  YaruPage(
                     child: TextField(
                       maxLines: 100,
-                      // expands: true,
                     ),
                   ),
                   Text('accessibility'),

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -1,0 +1,1 @@
+const kDefaultPagePadding = 20.0;

--- a/lib/src/yaru_landscape_layout.dart
+++ b/lib/src/yaru_landscape_layout.dart
@@ -44,14 +44,12 @@ class YaruLandscapeLayout extends StatefulWidget {
 
 class _YaruLandscapeLayoutState extends State<YaruLandscapeLayout> {
   late int _selectedIndex;
-  late ScrollController _contentScrollController;
   late TextEditingController _searchController;
   final _filteredItems = <YaruPageItem>[];
 
   @override
   void initState() {
     _selectedIndex = widget.selectedIndex;
-    _contentScrollController = ScrollController();
     _searchController = TextEditingController();
     super.initState();
   }

--- a/lib/src/yaru_landscape_layout.dart
+++ b/lib/src/yaru_landscape_layout.dart
@@ -117,22 +117,13 @@ class _YaruLandscapeLayoutState extends State<YaruLandscapeLayout> {
                         ? SingleChildScrollView(
                             controller: _contentScrollController,
                             child: Center(
-                              child: Padding(
-                                padding: EdgeInsets.all(
-                                    widget.pages[_selectedIndex].padding ??
-                                        0.0),
-                                child: widget.pages[_selectedIndex]
-                                    .builder(context),
-                              ),
-                            ),
-                          )
-                        : Center(
-                            child: Padding(
-                              padding: EdgeInsets.all(
-                                  widget.pages[_selectedIndex].padding ?? 0.0),
                               child:
                                   widget.pages[_selectedIndex].builder(context),
                             ),
+                          )
+                        : Center(
+                            child:
+                                widget.pages[_selectedIndex].builder(context),
                           )),
               ],
             ),

--- a/lib/src/yaru_landscape_layout.dart
+++ b/lib/src/yaru_landscape_layout.dart
@@ -113,18 +113,9 @@ class _YaruLandscapeLayoutState extends State<YaruLandscapeLayout> {
                   ),
                 ),
                 Expanded(
-                    child: widget.pages[_selectedIndex].wrapInScrollView != null
-                        ? SingleChildScrollView(
-                            controller: _contentScrollController,
-                            child: Center(
-                              child:
-                                  widget.pages[_selectedIndex].builder(context),
-                            ),
-                          )
-                        : Center(
-                            child:
-                                widget.pages[_selectedIndex].builder(context),
-                          )),
+                    child: Center(
+                  child: widget.pages[_selectedIndex].builder(context),
+                )),
               ],
             ),
           ),

--- a/lib/src/yaru_landscape_layout.dart
+++ b/lib/src/yaru_landscape_layout.dart
@@ -113,15 +113,27 @@ class _YaruLandscapeLayoutState extends State<YaruLandscapeLayout> {
                   ),
                 ),
                 Expanded(
-                    child: SingleChildScrollView(
-                  controller: _contentScrollController,
-                  child: Center(
-                    child: Padding(
-                      padding: const EdgeInsets.all(20.0),
-                      child: widget.pages[_selectedIndex].builder(context),
-                    ),
-                  ),
-                )),
+                    child: widget.pages[_selectedIndex].wrapInScrollView != null
+                        ? SingleChildScrollView(
+                            controller: _contentScrollController,
+                            child: Center(
+                              child: Padding(
+                                padding: EdgeInsets.all(
+                                    widget.pages[_selectedIndex].padding ??
+                                        0.0),
+                                child: widget.pages[_selectedIndex]
+                                    .builder(context),
+                              ),
+                            ),
+                          )
+                        : Center(
+                            child: Padding(
+                              padding: EdgeInsets.all(
+                                  widget.pages[_selectedIndex].padding ?? 0.0),
+                              child:
+                                  widget.pages[_selectedIndex].builder(context),
+                            ),
+                          )),
               ],
             ),
           ),

--- a/lib/src/yaru_landscape_layout.dart
+++ b/lib/src/yaru_landscape_layout.dart
@@ -112,10 +112,7 @@ class _YaruLandscapeLayoutState extends State<YaruLandscapeLayout> {
                     ),
                   ),
                 ),
-                Expanded(
-                    child: Center(
-                  child: widget.pages[_selectedIndex].builder(context),
-                )),
+                Expanded(child: widget.pages[_selectedIndex].builder(context)),
               ],
             ),
           ),

--- a/lib/src/yaru_page.dart
+++ b/lib/src/yaru_page.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:yaru_widgets/src/constants.dart';
+
+/// Wraps a child widget in a [ScrollView] and [Padding].
+/// The padding defaults to [kDefaultPagePadding]
+/// but can be set if wanted.
+class YaruPage extends StatelessWidget {
+  const YaruPage({Key? key, required this.child, this.padding})
+      : super(key: key);
+
+  final Widget child;
+  final double? padding;
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      child: Padding(
+        padding: EdgeInsets.all(padding ?? kDefaultPagePadding),
+        child: child,
+      ),
+    );
+  }
+}

--- a/lib/src/yaru_page.dart
+++ b/lib/src/yaru_page.dart
@@ -9,13 +9,13 @@ class YaruPage extends StatelessWidget {
       : super(key: key);
 
   final Widget child;
-  final double? padding;
+  final EdgeInsets? padding;
 
   @override
   Widget build(BuildContext context) {
     return SingleChildScrollView(
       child: Padding(
-        padding: EdgeInsets.all(padding ?? kDefaultPagePadding),
+        padding: padding ?? const EdgeInsets.all(kDefaultPagePadding),
         child: child,
       ),
     );

--- a/lib/src/yaru_page_item.dart
+++ b/lib/src/yaru_page_item.dart
@@ -5,10 +5,8 @@ class YaruPageItem {
     required this.title,
     required this.builder,
     required this.iconData,
-    this.wrapInScrollView,
   });
   final String title;
   final WidgetBuilder builder;
   final IconData iconData;
-  final bool? wrapInScrollView;
 }

--- a/lib/src/yaru_page_item.dart
+++ b/lib/src/yaru_page_item.dart
@@ -1,9 +1,16 @@
 import 'package:flutter/widgets.dart';
 
 class YaruPageItem {
-  const YaruPageItem(
-      {required this.title, required this.builder, required this.iconData});
+  const YaruPageItem({
+    required this.title,
+    required this.builder,
+    required this.iconData,
+    this.wrapInScrollView,
+    this.padding,
+  });
   final String title;
   final WidgetBuilder builder;
   final IconData iconData;
+  final bool? wrapInScrollView;
+  final double? padding;
 }

--- a/lib/src/yaru_page_item.dart
+++ b/lib/src/yaru_page_item.dart
@@ -6,11 +6,9 @@ class YaruPageItem {
     required this.builder,
     required this.iconData,
     this.wrapInScrollView,
-    this.padding,
   });
   final String title;
   final WidgetBuilder builder;
   final IconData iconData;
   final bool? wrapInScrollView;
-  final double? padding;
 }

--- a/lib/src/yaru_portrait_layout.dart
+++ b/lib/src/yaru_portrait_layout.dart
@@ -57,6 +57,7 @@ class _YaruPortraitLayoutState extends State<YaruPortraitLayout> {
   }
 
   MaterialPageRoute pageRoute(int index) {
+    final width = MediaQuery.of(context).size.width;
     return MaterialPageRoute(
       builder: (context) {
         final page = widget.pages[_selectedIndex];
@@ -72,9 +73,7 @@ class _YaruPortraitLayoutState extends State<YaruPortraitLayout> {
               },
             ),
           ),
-          body: Center(
-            child: page.builder(context),
-          ),
+          body: SizedBox(width: width, child: page.builder(context)),
         );
       },
     );

--- a/lib/src/yaru_portrait_layout.dart
+++ b/lib/src/yaru_portrait_layout.dart
@@ -72,14 +72,21 @@ class _YaruPortraitLayoutState extends State<YaruPortraitLayout> {
               },
             ),
           ),
-          body: SingleChildScrollView(
-            child: Center(
-              child: Padding(
-                padding: const EdgeInsets.all(20.0),
-                child: page.builder(context),
-              ),
-            ),
-          ),
+          body: page.wrapInScrollView != null
+              ? SingleChildScrollView(
+                  child: Center(
+                    child: Padding(
+                      padding: EdgeInsets.all(page.padding ?? 0.0),
+                      child: page.builder(context),
+                    ),
+                  ),
+                )
+              : Center(
+                  child: Padding(
+                    padding: EdgeInsets.all(page.padding ?? 0.0),
+                    child: page.builder(context),
+                  ),
+                ),
         );
       },
     );

--- a/lib/src/yaru_portrait_layout.dart
+++ b/lib/src/yaru_portrait_layout.dart
@@ -72,15 +72,9 @@ class _YaruPortraitLayoutState extends State<YaruPortraitLayout> {
               },
             ),
           ),
-          body: page.wrapInScrollView != null
-              ? SingleChildScrollView(
-                  child: Center(
-                    child: page.builder(context),
-                  ),
-                )
-              : Center(
-                  child: page.builder(context),
-                ),
+          body: Center(
+            child: page.builder(context),
+          ),
         );
       },
     );

--- a/lib/src/yaru_portrait_layout.dart
+++ b/lib/src/yaru_portrait_layout.dart
@@ -75,17 +75,11 @@ class _YaruPortraitLayoutState extends State<YaruPortraitLayout> {
           body: page.wrapInScrollView != null
               ? SingleChildScrollView(
                   child: Center(
-                    child: Padding(
-                      padding: EdgeInsets.all(page.padding ?? 0.0),
-                      child: page.builder(context),
-                    ),
+                    child: page.builder(context),
                   ),
                 )
               : Center(
-                  child: Padding(
-                    padding: EdgeInsets.all(page.padding ?? 0.0),
-                    child: page.builder(context),
-                  ),
+                  child: page.builder(context),
                 ),
         );
       },

--- a/lib/src/yaru_tabbed_page.dart
+++ b/lib/src/yaru_tabbed_page.dart
@@ -62,7 +62,10 @@ class _YaruTabbedPageState extends State<YaruTabbedPage>
     return Column(
       children: [
         Padding(
-          padding: const EdgeInsets.all(kDefaultPagePadding),
+          padding: const EdgeInsets.only(
+              top: kDefaultPagePadding,
+              right: kDefaultPagePadding,
+              left: kDefaultPagePadding),
           child: Container(
             width: widget.width,
             height: 60,

--- a/lib/src/yaru_tabbed_page.dart
+++ b/lib/src/yaru_tabbed_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:yaru_widgets/src/constants.dart';
 
 /// A width responsive widget combining a [TabBar] and a [TabBarView].
 ///
@@ -61,7 +62,7 @@ class _YaruTabbedPageState extends State<YaruTabbedPage>
     return Column(
       children: [
         Padding(
-          padding: const EdgeInsets.all(20),
+          padding: const EdgeInsets.all(kDefaultPagePadding),
           child: Container(
             width: widget.width,
             height: 60,

--- a/lib/src/yaru_tabbed_page.dart
+++ b/lib/src/yaru_tabbed_page.dart
@@ -5,14 +5,13 @@ import 'package:flutter/material.dart';
 /// [tabIcons], [views] and [tabTitles] must have the same amount of children. The [width] and [height] must be provided.
 /// If there is not enough space only the [tabIcons] are shown.
 class YaruTabbedPage extends StatefulWidget {
-  const YaruTabbedPage(
-      {Key? key,
-      required this.tabIcons,
-      required this.tabTitles,
-      required this.views,
-      required this.width,
-      required this.height})
-      : super(key: key);
+  const YaruTabbedPage({
+    Key? key,
+    required this.tabIcons,
+    required this.tabTitles,
+    required this.views,
+    this.width,
+  }) : super(key: key);
 
   /// A list of [IconData] used inside the tabs - must have the same length as [tabTitles] and [views].
   final List<IconData> tabIcons;
@@ -24,10 +23,7 @@ class YaruTabbedPage extends StatefulWidget {
   final List<Widget> views;
 
   /// The width used for the [TabBarView]
-  final double width;
-
-  /// The height  used for the [TabBarView]
-  final double height;
+  final double? width;
 
   @override
   State<YaruTabbedPage> createState() => _YaruTabbedPageState();
@@ -64,44 +60,43 @@ class _YaruTabbedPageState extends State<YaruTabbedPage>
 
     return Column(
       children: [
-        Container(
-          width: widget.width,
-          height: 60,
-          decoration: BoxDecoration(borderRadius: BorderRadius.circular(4)),
-          child: Theme(
-            data: ThemeData().copyWith(
-              splashColor: Colors.transparent,
-              hoverColor: Colors.transparent,
-              highlightColor: Colors.transparent,
-            ),
-            child: TabBar(
-              controller: tabController,
-              labelColor: Theme.of(context).colorScheme.onSurface,
-              indicator: BoxDecoration(
-                  borderRadius: BorderRadius.circular(4),
-                  color:
-                      Theme.of(context).colorScheme.onSurface.withOpacity(0.1)),
-              tabs: [
-                for (var i = 0; i < widget.views.length; i++)
-                  Tab(
-                      text: titlesDoNotFit() ? null : widget.tabTitles[i],
-                      icon: Icon(
-                        widget.tabIcons[i],
-                      ))
-              ],
+        Padding(
+          padding: const EdgeInsets.all(20),
+          child: Container(
+            width: widget.width,
+            height: 60,
+            decoration: BoxDecoration(borderRadius: BorderRadius.circular(4)),
+            child: Theme(
+              data: ThemeData().copyWith(
+                splashColor: Colors.transparent,
+                hoverColor: Colors.transparent,
+                highlightColor: Colors.transparent,
+              ),
+              child: TabBar(
+                controller: tabController,
+                labelColor: Theme.of(context).colorScheme.onSurface,
+                indicator: BoxDecoration(
+                    borderRadius: BorderRadius.circular(4),
+                    color: Theme.of(context)
+                        .colorScheme
+                        .onSurface
+                        .withOpacity(0.1)),
+                tabs: [
+                  for (var i = 0; i < widget.views.length; i++)
+                    Tab(
+                        text: titlesDoNotFit() ? null : widget.tabTitles[i],
+                        icon: Icon(
+                          widget.tabIcons[i],
+                        ))
+                ],
+              ),
             ),
           ),
         ),
-        Padding(
-          padding: const EdgeInsets.only(top: 30),
-          child: SingleChildScrollView(
-            child: SizedBox(
-              height: widget.height,
-              child: TabBarView(
-                controller: tabController,
-                children: widget.views,
-              ),
-            ),
+        Expanded(
+          child: TabBarView(
+            controller: tabController,
+            children: widget.views,
           ),
         ),
       ],

--- a/lib/yaru_widgets.dart
+++ b/lib/yaru_widgets.dart
@@ -8,6 +8,7 @@ export 'src/yaru_master_detail_page.dart';
 export 'src/yaru_option_button.dart';
 export 'src/yaru_option_card.dart';
 export 'src/yaru_page_container.dart';
+export 'src/yaru_page.dart';
 export 'src/yaru_page_item.dart';
 export 'src/yaru_row.dart';
 export 'src/yaru_search_app_bar.dart';


### PR DESCRIPTION
- YaruPageItems now have an optional wrapInScrollView field which is used in both Portrait and Landscape layout to decided if one wants to wrap the item in yet another scrollview because this is not always needed and often harms the whole situation of adding unpredicted content to a page
- YaruPageItems also make the padding optional so each page has more freedom
- YaruTabbedPage now does not include SingleChildScrollview but expands the bottom content so the tab header stays even if the bottom content is scrollable
- updated the example to visualize this better
- updated the example to expand option cards
- remove height from YaruTabbedPage
- make the width of YaruTabbedPage optional so one can decide if the tabs should expand to the parent width or not