### PR TITLE
Add an alternative layout

### DIFF
--- a/example/lib/alternative_main.dart
+++ b/example/lib/alternative_main.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:yaru/yaru.dart' as yaru;
+import 'package:yaru_icons/yaru_icons.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
+
+void main() {
+  runApp(const App());
+}
+
+class App extends StatelessWidget {
+  const App({Key? key}) : super(key: key);
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Yaru Demo',
+      theme: yaru.lightTheme,
+      darkTheme: yaru.darkTheme,
+      home: const HomePage(),
+    );
+  }
+}
+
+class HomePage extends StatelessWidget {
+  const HomePage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Scaffold(
+        appBar: YaruSearchAppBar(
+            searchIconData: YaruIcons.search,
+            searchController: TextEditingController(),
+            onChanged: (value) {},
+            onEscape: () {},
+            automaticallyImplyLeading: true),
+        body: LayoutBuilder(
+            builder: (context, constraints) => constraints.maxWidth > 600
+                ? YaruWideLayout(pageItems: pageItems)
+                : YaruNarrowLayout(pageItems: pageItems)),
+      ),
+    );
+  }
+}
+
+final pageItems = [
+  YaruPageItem(
+      title: 'Home',
+      builder: (_) => const Text('Home'),
+      iconData: YaruIcons.home,
+      selectedIconData: YaruIcons.home_filled),
+  YaruPageItem(
+      title: 'View',
+      builder: (_) => const YaruTabbedPage(tabIcons: [
+            YaruIcons.lock_filled,
+            YaruIcons.globe_filled,
+            YaruIcons.power_filled
+          ], tabTitles: [
+            'Lock',
+            'Globe',
+            'Power'
+          ], views: [
+            Center(child: Text('Lock')),
+            Center(child: Text('Globe')),
+            Center(child: Text('Power'))
+          ]),
+      iconData: YaruIcons.view,
+      selectedIconData: YaruIcons.view_filled),
+  YaruPageItem(
+      title: 'Time',
+      builder: (_) => const Text('Time'),
+      iconData: YaruIcons.clock,
+      selectedIconData: YaruIcons.clock_filled),
+  YaruPageItem(
+      title: 'Favorites',
+      builder: (_) => const Text('Favorites'),
+      iconData: YaruIcons.star,
+      selectedIconData: YaruIcons.star_filled),
+  YaruPageItem(
+      title: 'Electronics',
+      builder: (_) => const Text('Electronics'),
+      iconData: YaruIcons.chip,
+      selectedIconData: YaruIcons.chip_filled),
+  YaruPageItem(
+      title: 'Gallery',
+      builder: (_) => const Text('Gallery'),
+      iconData: YaruIcons.image,
+      selectedIconData: YaruIcons.image_filled),
+];

--- a/example/lib/widgets/list_yaru_options.dart
+++ b/example/lib/widgets/list_yaru_options.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:yaru_icons/widgets/yaru_icons.dart';
+import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
 class YaruOptionsButtonsList extends StatelessWidget {

--- a/example/lib/widgets/yaru_option_card_list.dart
+++ b/example/lib/widgets/yaru_option_card_list.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:yaru_icons/widgets/yaru_icons.dart';
+import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
 class YaruOptionCardList extends StatelessWidget {

--- a/example/lib/widgets/yaru_row_list.dart
+++ b/example/lib/widgets/yaru_row_list.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:yaru_icons/widgets/yaru_icons.dart';
+import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
 class YaruRowList extends StatelessWidget {

--- a/example/lib/yaru_home.dart
+++ b/example/lib/yaru_home.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:yaru_icons/widgets/yaru_icons.dart';
+import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 import 'package:yaru_widgets_example/widgets/list_yaru_options.dart';
 import 'package:yaru_widgets_example/widgets/yaru_option_card_list.dart';

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
   yaru: ^0.1.8
-  yaru_icons: ^0.0.6
+  yaru_icons: ^0.1.2
   yaru_widgets:
     path: ../
 

--- a/lib/src/yaru_narrow_layout.dart
+++ b/lib/src/yaru_narrow_layout.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
+
+class YaruNarrowLayout extends StatefulWidget {
+  final List<YaruPageItem> pageItems;
+
+  const YaruNarrowLayout({Key? key, required this.pageItems}) : super(key: key);
+
+  @override
+  _YaruNarrowLayoutState createState() => _YaruNarrowLayoutState();
+}
+
+class _YaruNarrowLayoutState extends State<YaruNarrowLayout> {
+  late int _selectedIndex;
+  @override
+  void initState() {
+    _selectedIndex = 0;
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Scaffold(
+          body: Column(
+        children: <Widget>[
+          Expanded(
+            child: Center(
+              child: widget.pageItems[_selectedIndex].builder(context),
+            ),
+          ),
+          BottomNavigationBar(
+            items: widget.pageItems
+                .map((pageItem) => BottomNavigationBarItem(
+                    icon: Icon(pageItem.iconData),
+                    activeIcon: Icon(pageItem.selectedIconData),
+                    label: pageItem.title))
+                .toList(),
+            currentIndex: _selectedIndex,
+            onTap: (index) => setState(() => _selectedIndex = index),
+          ),
+        ],
+      )),
+    );
+  }
+}

--- a/lib/src/yaru_wide_layout.dart
+++ b/lib/src/yaru_wide_layout.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
+
+class YaruWideLayout extends StatefulWidget {
+  final List<YaruPageItem> pageItems;
+
+  const YaruWideLayout({Key? key, required this.pageItems}) : super(key: key);
+
+  @override
+  _YaruWideLayoutState createState() => _YaruWideLayoutState();
+}
+
+class _YaruWideLayoutState extends State<YaruWideLayout> {
+  late int _selectedIndex;
+
+  @override
+  void initState() {
+    _selectedIndex = 0;
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(builder: (context, constraint) {
+      return SafeArea(
+        child: Scaffold(
+          body: Row(
+            children: [
+              SizedBox(
+                height: MediaQuery.of(context).size.height,
+                child: SingleChildScrollView(
+                  child: ConstrainedBox(
+                      constraints:
+                          BoxConstraints(minHeight: constraint.maxHeight),
+                      child: IntrinsicHeight(
+                        child: NavigationRail(
+                          selectedIndex: _selectedIndex,
+                          onDestinationSelected: (index) =>
+                              setState(() => _selectedIndex = index),
+                          labelType: NavigationRailLabelType.selected,
+                          destinations: widget.pageItems
+                              .map((pageItem) => NavigationRailDestination(
+                                  icon: Icon(pageItem.iconData),
+                                  selectedIcon: Icon(pageItem.selectedIconData),
+                                  label: Text(pageItem.title)))
+                              .toList(),
+                        ),
+                      )),
+                ),
+              ),
+              const VerticalDivider(thickness: 1, width: 1),
+              Expanded(
+                child: Center(
+                  child: widget.pageItems[_selectedIndex].builder(context),
+                ),
+              )
+            ],
+          ),
+        ),
+      );
+    });
+  }
+}

--- a/lib/yaru_widgets.dart
+++ b/lib/yaru_widgets.dart
@@ -19,3 +19,5 @@ export 'src/yaru_slider_row.dart';
 export 'src/yaru_switch_row.dart';
 export 'src/yaru_toggle_buttons_row.dart';
 export 'src/yaru_tabbed_page.dart';
+export 'src/yaru_wide_layout.dart';
+export 'src/yaru_narrow_layout.dart';


### PR DESCRIPTION
When one has many YaruPageItems the YaruMasterDetailsPage is a great choice for both 600+ windows and windows <= 600 pixels.
However sometimes you do not want to navigate back to the list of YaruPageItems and instead want a bottom navigation bar. Especially when you only have 3-10 items.
That's why I am adding two additional, much simpler layouts

YaruNarrowLayout, which includes a bottom navigation bar, which can be combined with
YaruWideLayout, which includes a navigation rail

Both can be combined with a searchbar but do not have to. But both need YaruPageItems to create the corresponding views and menu items.

![ya](https://user-images.githubusercontent.com/15329494/150767889-8cecf5c8-5e0a-4ba7-99c3-e80ad05c6764.gif)
