### PR TITLE
YaruAlertDialog: more freedom for the content

### DIFF
--- a/example/lib/yaru_home.dart
+++ b/example/lib/yaru_home.dart
@@ -69,7 +69,7 @@ class _YaruHomeState extends State<YaruHome> {
                   builder: (_) => YaruSimpleDialog(
                         titleTextAlign: TextAlign.center,
                         width: 500,
-                        title: 'Test',
+                        title: 'YaruDialogTitle',
                         closeIconData: YaruIcons.window_close,
                         children: [
                           Text(
@@ -92,7 +92,7 @@ class _YaruHomeState extends State<YaruHome> {
               actionDescription: "Action Description",
             ),
             YaruExtraOptionRow(
-              actionLabel: "YaruDialogTitle",
+              actionLabel: "YaruAlertDialog",
               iconData: YaruIcons.warning,
               onChanged: (c) {
                 setState(() {
@@ -103,12 +103,13 @@ class _YaruHomeState extends State<YaruHome> {
                 context: context,
                 builder: (_) => YaruAlertDialog(
                   closeIconData: YaruIcons.window_close,
-                  title: 'YaruAlertDialog Title',
-                  children: [
-                    for (var i = 0; i < 20; i++)
-                      YaruSingleInfoRow(
-                          infoLabel: 'infoLabel', infoValue: 'infoValue')
-                  ],
+                  title: 'YaruDialogTitle',
+                  child: YaruPage(
+                      padding: EdgeInsets.only(top: 0, right: 20, left: 20),
+                      children: [
+                        for (var i = 0; i < 5; i++)
+                          generateDummySection(width: null)
+                      ]),
                   actions: [
                     OutlinedButton(
                         onPressed: () => Navigator.of(context).pop(),
@@ -122,7 +123,7 @@ class _YaruHomeState extends State<YaruHome> {
                         child: Text('OK'))
                   ],
                   width: 500,
-                  height: 400,
+                  height: 300,
                 ),
               ),
               value: _extraOptionValue,
@@ -221,40 +222,8 @@ class _YaruHomeState extends State<YaruHome> {
         iconData: YaruIcons.emote_glasses,
         builder: (_) => YaruPage(
           children: [
-            YaruSection(
-              headline: 'Headline',
-              headerWidget: SizedBox(
-                child: CircularProgressIndicator(),
-                height: 20,
-                width: 20,
-              ),
-              children: [
-                YaruRow(
-                  enabled: true,
-                  trailingWidget: Text("Trailing Widget"),
-                  actionWidget: Text("Action Widget"),
-                  description: "Description",
-                ),
-              ],
-              // width: 400,
-            ),
-            YaruSection(
-              headline: 'Headline',
-              headerWidget: SizedBox(
-                child: CircularProgressIndicator(),
-                height: 20,
-                width: 20,
-              ),
-              children: [
-                YaruRow(
-                  enabled: true,
-                  trailingWidget: Text("Trailing Widget"),
-                  actionWidget: Text("Action Widget"),
-                  description: "Description",
-                ),
-              ],
-              width: 300,
-            ),
+            generateDummySection(),
+            generateDummySection(width: 300),
             YaruSection(
               width: sectionWidth,
               headline: 'Headline',
@@ -481,6 +450,26 @@ class _YaruHomeState extends State<YaruHome> {
       searchHint: 'Search...',
       searchIconData: YaruIcons.search,
       pageItems: pageItems,
+    );
+  }
+
+  YaruSection generateDummySection({double? width}) {
+    return YaruSection(
+      headline: 'Headline',
+      headerWidget: SizedBox(
+        child: CircularProgressIndicator(),
+        height: 20,
+        width: 20,
+      ),
+      children: [
+        YaruRow(
+          enabled: true,
+          trailingWidget: Text("Trailing Widget"),
+          actionWidget: Text("Action Widget"),
+          description: "Description",
+        ),
+      ],
+      width: width,
     );
   }
 }

--- a/lib/src/yaru_alert_dialog.dart
+++ b/lib/src/yaru_alert_dialog.dart
@@ -6,13 +6,14 @@ class YaruAlertDialog extends StatelessWidget {
   const YaruAlertDialog({
     Key? key,
     required this.title,
+    required this.child,
     this.closeIconData,
-    required this.children,
     this.alignment,
     this.width,
     this.height,
     this.titleTextAlign,
     this.actions,
+    this.scrollable = false,
   }) : super(key: key);
 
   /// The title of the dialog, displayed in a large font at the top of the [YaruDialogTitle].
@@ -21,8 +22,9 @@ class YaruAlertDialog extends StatelessWidget {
   /// The icon used inside the close button
   final IconData? closeIconData;
 
-  /// The content of the dialog, displayed underneath the title.
-  final List<Widget> children;
+  /// The child displayed underneath the title. It comes without any padding
+  /// or [ScrollView] so one has the full freedom to put anything inside.
+  final Widget child;
 
   /// How to align the [Dialog] on the Screen.
   ///
@@ -45,32 +47,29 @@ class YaruAlertDialog extends StatelessWidget {
   /// A [List] of [Widget] - typically [OutlinedButton], [ElevatedButton] or [TextButton]
   final List<Widget>? actions;
 
+  /// Forwards the [scrollable] flag to the [AlertDialog]
+  final bool? scrollable;
+
   @override
   Widget build(BuildContext context) {
     return SizedBox(
       width: width ?? kDefaultPageWidth,
       child: AlertDialog(
         actionsPadding: const EdgeInsets.all(kDefaultPagePadding / 2),
-        contentPadding: const EdgeInsets.fromLTRB(kDefaultPagePadding,
-            kDefaultPagePadding / 2, kDefaultPagePadding, kDefaultPagePadding),
-        titlePadding: const EdgeInsets.all(kDefaultDialogTitlePadding),
+        contentPadding: EdgeInsets.zero,
+        scrollable: scrollable ?? false,
+        titlePadding: const EdgeInsets.only(
+            top: kDefaultDialogTitlePadding,
+            left: kDefaultDialogTitlePadding,
+            right: kDefaultDialogTitlePadding,
+            bottom: 0),
         title: YaruDialogTitle(
           mainAxisAlignment: MainAxisAlignment.start,
           textAlign: titleTextAlign,
           title: title,
           closeIconData: closeIconData ?? Icons.close,
         ),
-        content: SizedBox(
-          height: height,
-          child: SingleChildScrollView(
-            child: Column(
-              children: [
-                for (var child in children)
-                  SizedBox(child: child, width: width ?? kDefaultPageWidth)
-              ],
-            ),
-          ),
-        ),
+        content: SizedBox(height: height, width: width, child: child),
         actions: actions,
         alignment: alignment,
       ),


### PR DESCRIPTION
Since we have YaruDialogTitle which includes our desired styling and close button, we should not force the AlertDialog into a certain content.
This removes content padding and the column inside to let us chose whatever content we like. If it is something standartized we can just insert a YaruPage and it already looks good out of the box.

![yayayayasfdasdf123123](https://user-images.githubusercontent.com/15329494/152437000-702530d2-b80a-49c7-9e9c-fe6e9437c617.gif)

