### PR TITLE
Bugfix/screenshot path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Common flutter widgets useful for building desktop and web applications.
 
-![screenshot_dark](.github/images/screenshot_dark.png)
+![screenshot_dark](https://raw.githubusercontent.com/ubuntu/yaru_widgets.dart/main/.github/images/screenshot_dark.png)
 
 ## What is this?
 


### PR DESCRIPTION
Thanks for creating this package :)

Although the file `.github/images/screenshot_dark.png` is displayed correctly on [GitHub](https://github.com/ubuntu/yaru_widgets.dart#readme), it is not displayed correctly on [pub.dev](https://pub.dev/packages/yaru_widgets). By using a raw link, this image will be displayed correctly on both websites.

Feel free to close if you feel it is not applicable. However, I believe other developers would benefit from seeing a screenshot on pub.dev.