### PR TITLE
YaruSearchAppBar: default to theme's appbar height

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -17,7 +17,6 @@ class Home extends StatelessWidget {
       theme: yaruLight,
       darkTheme: yaruDark,
       home: YaruMasterDetailPage(
-        appBarHeight: 48,
         leftPaneWidth: 280,
         previousIconData: YaruIcons.go_previous,
         searchHint: 'Search...',

--- a/lib/src/yaru_search_app_bar.dart
+++ b/lib/src/yaru_search_app_bar.dart
@@ -17,7 +17,7 @@ class YaruSearchAppBar extends StatelessWidget implements PreferredSizeWidget {
     required this.onEscape,
     required this.automaticallyImplyLeading,
     this.searchIconData,
-    this.appBarHeight = kToolbarHeight,
+    this.appBarHeight,
     this.textStyle,
     this.searchHint,
   }) : super(key: key);
@@ -50,7 +50,8 @@ class YaruSearchAppBar extends StatelessWidget implements PreferredSizeWidget {
   Widget build(BuildContext context) {
     final textColor = Theme.of(context).appBarTheme.foregroundColor;
     return AppBar(
-      toolbarHeight: appBarHeight ?? kToolbarHeight,
+      toolbarHeight:
+          appBarHeight ?? Theme.of(context).appBarTheme.toolbarHeight,
       automaticallyImplyLeading: automaticallyImplyLeading,
       flexibleSpace: RawKeyboardListener(
         onKey: (event) {
@@ -61,7 +62,7 @@ class YaruSearchAppBar extends StatelessWidget implements PreferredSizeWidget {
         },
         focusNode: FocusNode(),
         child: SizedBox(
-          height: appBarHeight ?? kToolbarHeight,
+          height: appBarHeight ?? Theme.of(context).appBarTheme.toolbarHeight,
           child: Padding(
             padding: const EdgeInsets.only(top: 4),
             child: TextField(


### PR DESCRIPTION
- if the theme does not specify an appbar height, the searchappbar defaults to the material constant kToolbarHeight

Not specified:
![image](https://user-images.githubusercontent.com/15329494/153574209-d34b441a-ee9a-4dc2-aabc-a7372cf12e55.png)

Specified:
![image](https://user-images.githubusercontent.com/15329494/153574417-c37a068b-6d89-4a5c-b8da-18b97a378070.png)
