### PR TITLE
Remove hardcoded search

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -8,8 +8,29 @@ void main() {
   runApp(Home());
 }
 
-class Home extends StatelessWidget {
+class Home extends StatefulWidget {
   const Home({Key? key}) : super(key: key);
+
+  @override
+  State<Home> createState() => _HomeState();
+}
+
+class _HomeState extends State<Home> {
+  final _filteredItems = <YaruPageItem>[];
+  final _searchController = TextEditingController();
+
+  void _onEscape() => setState(() {
+        _filteredItems.clear();
+        _searchController.clear();
+      });
+
+  void _onSearchChanged(String value) {
+    setState(() {
+      _filteredItems.clear();
+      _filteredItems.addAll(examplePageItems.where((element) =>
+          element.title.toLowerCase().contains(value.toLowerCase())));
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -23,7 +44,18 @@ class Home extends StatelessWidget {
         searchHint: 'Search...',
         searchIconData: YaruIcons.search,
         clearSearchIconData: YaruIcons.window_close,
-        pageItems: examplePageItems,
+        pageItems:
+            _filteredItems.isNotEmpty ? _filteredItems : examplePageItems,
+        appBar: YaruSearchAppBar(
+          searchHint: 'Search...',
+          clearSearchIconData: YaruIcons.window_close,
+          searchController: _searchController,
+          onChanged: _onSearchChanged,
+          onEscape: _onEscape,
+          appBarHeight: 48,
+          searchIconData: YaruIcons.search,
+          automaticallyImplyLeading: false,
+        ),
       ),
     );
   }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -46,16 +46,16 @@ class _HomeState extends State<Home> {
         clearSearchIconData: YaruIcons.window_close,
         pageItems:
             _filteredItems.isNotEmpty ? _filteredItems : examplePageItems,
-        appBar: YaruSearchAppBar(
-          searchHint: 'Search...',
-          clearSearchIconData: YaruIcons.window_close,
-          searchController: _searchController,
-          onChanged: _onSearchChanged,
-          onEscape: _onEscape,
-          appBarHeight: 48,
-          searchIconData: YaruIcons.search,
-          automaticallyImplyLeading: false,
-        ),
+        // appBar: YaruSearchAppBar(
+        //   searchHint: 'Search...',
+        //   clearSearchIconData: YaruIcons.window_close,
+        //   searchController: _searchController,
+        //   onChanged: _onSearchChanged,
+        //   onEscape: _onEscape,
+        //   appBarHeight: 48,
+        //   searchIconData: YaruIcons.search,
+        //   automaticallyImplyLeading: false,
+        // ),
       ),
     );
   }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -46,16 +46,16 @@ class _HomeState extends State<Home> {
         clearSearchIconData: YaruIcons.window_close,
         pageItems:
             _filteredItems.isNotEmpty ? _filteredItems : examplePageItems,
-        // appBar: YaruSearchAppBar(
-        //   searchHint: 'Search...',
-        //   clearSearchIconData: YaruIcons.window_close,
-        //   searchController: _searchController,
-        //   onChanged: _onSearchChanged,
-        //   onEscape: _onEscape,
-        //   appBarHeight: 48,
-        //   searchIconData: YaruIcons.search,
-        //   automaticallyImplyLeading: false,
-        // ),
+        appBar: YaruSearchAppBar(
+          searchHint: 'Search...',
+          clearSearchIconData: YaruIcons.window_close,
+          searchController: _searchController,
+          onChanged: _onSearchChanged,
+          onEscape: _onEscape,
+          appBarHeight: 48,
+          searchIconData: YaruIcons.search,
+          automaticallyImplyLeading: false,
+        ),
       ),
     );
   }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -14,6 +14,7 @@ class Home extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
+      debugShowCheckedModeBanner: false,
       theme: yaruLight,
       darkTheme: yaruDark,
       home: YaruMasterDetailPage(
@@ -21,6 +22,7 @@ class Home extends StatelessWidget {
         previousIconData: YaruIcons.go_previous,
         searchHint: 'Search...',
         searchIconData: YaruIcons.search,
+        clearSearchIconData: YaruIcons.window_close,
         pageItems: examplePageItems,
       ),
     );

--- a/lib/src/yaru_landscape_layout.dart
+++ b/lib/src/yaru_landscape_layout.dart
@@ -26,6 +26,9 @@ class YaruLandscapeLayout extends StatefulWidget {
 
   /// Specifies the width of left pane.
   final double leftPaneWidth;
+
+  /// An optional [PreferredSizeWidget] used as the left [AppBar]
+  /// If provided, a second [AppBar] will be created right to it.
   final PreferredSizeWidget? appBar;
 
   @override
@@ -52,21 +55,23 @@ class _YaruLandscapeLayoutState extends State<YaruLandscapeLayout> {
       body: Column(
         children: [
           SizedBox(
-            height:
-                Theme.of(context).appBarTheme.toolbarHeight ?? kToolbarHeight,
+            height: widget.appBar != null
+                ? Theme.of(context).appBarTheme.toolbarHeight ?? kToolbarHeight
+                : 0,
             child: Row(
               children: [
                 SizedBox(
                   width: widget.leftPaneWidth,
-                  child: widget.appBar ?? AppBar(),
+                  child: widget.appBar,
                 ),
-                Expanded(
-                  child: AppBar(
-                    title: widget.pageItems.length > _selectedIndex
-                        ? Text(widget.pageItems[_selectedIndex].title)
-                        : Text(widget.pageItems[0].title),
-                  ),
-                )
+                if (widget.appBar != null)
+                  Expanded(
+                    child: AppBar(
+                      title: widget.pageItems.length > _selectedIndex
+                          ? Text(widget.pageItems[_selectedIndex].title)
+                          : Text(widget.pageItems[0].title),
+                    ),
+                  )
               ],
             ),
           ),

--- a/lib/src/yaru_landscape_layout.dart
+++ b/lib/src/yaru_landscape_layout.dart
@@ -44,7 +44,7 @@ class _YaruLandscapeLayoutState extends State<YaruLandscapeLayout> {
     super.initState();
   }
 
-  void onTap(int index) {
+  void _onTap(int index) {
     widget.onSelected(index);
     setState(() => _selectedIndex = index);
   }
@@ -93,7 +93,7 @@ class _YaruLandscapeLayoutState extends State<YaruLandscapeLayout> {
                     ),
                     child: YaruPageItemListView(
                         selectedIndex: _selectedIndex,
-                        onTap: onTap,
+                        onTap: _onTap,
                         pages: widget.pageItems),
                   ),
                 ),

--- a/lib/src/yaru_landscape_layout.dart
+++ b/lib/src/yaru_landscape_layout.dart
@@ -8,7 +8,7 @@ class YaruLandscapeLayout extends StatefulWidget {
   const YaruLandscapeLayout({
     Key? key,
     required this.selectedIndex,
-    this.pageItems = const [],
+    required this.pageItems,
     required this.onSelected,
     required this.leftPaneWidth,
     this.appBar,
@@ -62,7 +62,9 @@ class _YaruLandscapeLayoutState extends State<YaruLandscapeLayout> {
                 ),
                 Expanded(
                   child: AppBar(
-                    title: Text(widget.pageItems[_selectedIndex].title),
+                    title: widget.pageItems.length > _selectedIndex
+                        ? Text(widget.pageItems[_selectedIndex].title)
+                        : Text(widget.pageItems[0].title),
                   ),
                 )
               ],
@@ -91,7 +93,9 @@ class _YaruLandscapeLayoutState extends State<YaruLandscapeLayout> {
                   ),
                 ),
                 Expanded(
-                    child: widget.pageItems[_selectedIndex].builder(context)),
+                    child: widget.pageItems.length > _selectedIndex
+                        ? widget.pageItems[_selectedIndex].builder(context)
+                        : widget.pageItems[0].builder(context)),
               ],
             ),
           ),

--- a/lib/src/yaru_landscape_layout.dart
+++ b/lib/src/yaru_landscape_layout.dart
@@ -8,7 +8,7 @@ class YaruLandscapeLayout extends StatefulWidget {
   const YaruLandscapeLayout({
     Key? key,
     required this.selectedIndex,
-    required this.pageItems,
+    this.pageItems = const [],
     required this.onSelected,
     required this.leftPaneWidth,
     this.appBar,

--- a/lib/src/yaru_landscape_layout.dart
+++ b/lib/src/yaru_landscape_layout.dart
@@ -1,38 +1,32 @@
 import 'package:flutter/material.dart';
 import 'package:yaru_widgets/src/yaru_page_item_list_view.dart';
-import 'package:yaru_widgets/src/yaru_search_app_bar.dart';
+
 import 'yaru_page_item.dart';
 
 class YaruLandscapeLayout extends StatefulWidget {
-  // Creates a landscape layout
+  /// Creates a landscape layout
   const YaruLandscapeLayout({
     Key? key,
     required this.selectedIndex,
-    required this.pages,
+    required this.pageItems,
     required this.onSelected,
     required this.leftPaneWidth,
-    this.searchIconData,
-    this.searchHint,
+    this.appBar,
   }) : super(key: key);
 
-  // Current index of the selected page.
+  /// Current index of the selected page.
   final int selectedIndex;
 
-  // Creates horizontal array of pages.
-  // All the `children` will be of type [YaruPageItem]
-  final List<YaruPageItem> pages;
+  /// Creates horizontal array of pages.
+  /// All the `children` will be of type [YaruPageItem]
+  final List<YaruPageItem> pageItems;
 
-  // Callback that returns an index when the page changes.
+  /// Callback that returns an index when the page changes.
   final ValueChanged<int> onSelected;
 
-  // Specifies the width of left pane.
+  /// Specifies the width of left pane.
   final double leftPaneWidth;
-
-  // The icon that is given to the search widget.
-  final IconData? searchIconData;
-
-  // The hint text given to the search widget.
-  final String? searchHint;
+  final PreferredSizeWidget? appBar;
 
   @override
   State<YaruLandscapeLayout> createState() => _YaruLandscapeLayoutState();
@@ -40,22 +34,14 @@ class YaruLandscapeLayout extends StatefulWidget {
 
 class _YaruLandscapeLayoutState extends State<YaruLandscapeLayout> {
   late int _selectedIndex;
-  late TextEditingController _searchController;
-  final _filteredItems = <YaruPageItem>[];
 
   @override
   void initState() {
     _selectedIndex = widget.selectedIndex;
-    _searchController = TextEditingController();
     super.initState();
   }
 
   void onTap(int index) {
-    if (_filteredItems.isNotEmpty) {
-      index = widget.pages.indexOf(widget.pages.firstWhere(
-          (pageItem) => pageItem.title == _filteredItems[index].title));
-    }
-
     widget.onSelected(index);
     setState(() => _selectedIndex = index);
   }
@@ -72,11 +58,11 @@ class _YaruLandscapeLayoutState extends State<YaruLandscapeLayout> {
               children: [
                 SizedBox(
                   width: widget.leftPaneWidth,
-                  child: addSearchBar(),
+                  child: widget.appBar ?? AppBar(),
                 ),
                 Expanded(
                   child: AppBar(
-                    title: Text(widget.pages[_selectedIndex].title),
+                    title: Text(widget.pageItems[_selectedIndex].title),
                   ),
                 )
               ],
@@ -99,47 +85,18 @@ class _YaruLandscapeLayoutState extends State<YaruLandscapeLayout> {
                       ),
                     ),
                     child: YaruPageItemListView(
-                      selectedIndex: _selectedIndex,
-                      onTap: onTap,
-                      pages: _filteredItems.isEmpty
-                          ? widget.pages
-                          : _filteredItems,
-                    ),
+                        selectedIndex: _selectedIndex,
+                        onTap: onTap,
+                        pages: widget.pageItems),
                   ),
                 ),
-                Expanded(child: widget.pages[_selectedIndex].builder(context)),
+                Expanded(
+                    child: widget.pageItems[_selectedIndex].builder(context)),
               ],
             ),
           ),
         ],
       ),
-    );
-  }
-
-  YaruSearchAppBar addSearchBar() {
-    return YaruSearchAppBar(
-      automaticallyImplyLeading: false,
-      searchHint: widget.searchHint,
-      searchController: _searchController,
-      onChanged: (value) {
-        setState(() {
-          _filteredItems.clear();
-          for (YaruPageItem pageItem in widget.pages) {
-            if (pageItem.title
-                .toLowerCase()
-                .contains(_searchController.value.text.toLowerCase())) {
-              _filteredItems.add(pageItem);
-            }
-          }
-        });
-      },
-      onEscape: () => setState(() {
-        _searchController.clear();
-        _filteredItems.clear();
-      }),
-      appBarHeight:
-          Theme.of(context).appBarTheme.toolbarHeight ?? kToolbarHeight,
-      searchIconData: widget.searchIconData,
     );
   }
 }

--- a/lib/src/yaru_master_detail_page.dart
+++ b/lib/src/yaru_master_detail_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:yaru_widgets/src/yaru_landscape_layout.dart';
 import 'package:yaru_widgets/src/yaru_page_item.dart';
 import 'package:yaru_widgets/src/yaru_portrait_layout.dart';
+import 'package:yaru_widgets/src/yaru_search_app_bar.dart';
 
 class YaruMasterDetailPage extends StatefulWidget {
   /// Creates a basic responsive layout with yaru theme,
@@ -16,8 +17,6 @@ class YaruMasterDetailPage extends StatefulWidget {
   ///       appBarHeight: 48,
   ///       leftPaneWidth: 280,
   ///       previousIconData: YaruIcons.go_previous,
-  ///       searchHint: 'Search...',
-  ///       searchIconData: YaruIcons.search,
   ///      pageItems: pageItems,
   ///     );
   /// ```
@@ -28,6 +27,7 @@ class YaruMasterDetailPage extends StatefulWidget {
     this.searchIconData,
     required this.leftPaneWidth,
     this.searchHint,
+    this.clearSearchIconData,
   }) : super(key: key);
 
   /// Creates horizontal array of pages.
@@ -45,6 +45,9 @@ class YaruMasterDetailPage extends StatefulWidget {
   /// The icon that is given to the search widget.
   final IconData? searchIconData;
 
+  /// Search icon for search bar.
+  final IconData? clearSearchIconData;
+
   /// The hint text given to the search widget.
   final String? searchHint;
 
@@ -55,10 +58,33 @@ class YaruMasterDetailPage extends StatefulWidget {
 class _YaruMasterDetailPageState extends State<YaruMasterDetailPage> {
   var _index = -1;
   var _previousIndex = 0;
+  late List<YaruPageItem> _filteredItems;
+  late TextEditingController _searchController;
+
+  @override
+  void initState() {
+    _filteredItems = <YaruPageItem>[...widget.pageItems];
+    _searchController = TextEditingController();
+    super.initState();
+  }
 
   void _setIndex(int index) {
     _previousIndex = _index;
     _index = index;
+  }
+
+  void _onEscape() => setState(() {
+        _filteredItems.clear();
+        _searchController.clear();
+      });
+
+  void _onSearchChanged(value) {
+    setState(() {
+      _filteredItems.clear();
+      _filteredItems.addAll(widget.pageItems.where((element) => element.title
+          .toLowerCase()
+          .contains(_searchController.value.text.toLowerCase())));
+    });
   }
 
   @override
@@ -68,20 +94,40 @@ class _YaruMasterDetailPageState extends State<YaruMasterDetailPage> {
         if (constraints.maxWidth < 620) {
           return YaruPortraitLayout(
             selectedIndex: _index,
-            pages: widget.pageItems,
+            pageItems:
+                _filteredItems.isEmpty ? widget.pageItems : _filteredItems,
             onSelected: _setIndex,
             previousIconData: widget.previousIconData,
-            searchIconData: widget.searchIconData,
-            searchHint: widget.searchHint,
+            yaruSearchAppBar: YaruSearchAppBar(
+              searchHint: widget.searchHint,
+              clearSearchIconData: widget.clearSearchIconData,
+              searchController: _searchController,
+              onChanged: _onSearchChanged,
+              onEscape: _onEscape,
+              appBarHeight:
+                  Theme.of(context).appBarTheme.toolbarHeight ?? kToolbarHeight,
+              searchIconData: widget.searchIconData,
+              automaticallyImplyLeading: false,
+            ),
           );
         } else {
           return YaruLandscapeLayout(
             selectedIndex: _index == -1 ? _previousIndex : _index,
-            pages: widget.pageItems,
+            pageItems:
+                _filteredItems.isEmpty ? widget.pageItems : _filteredItems,
             onSelected: _setIndex,
             leftPaneWidth: widget.leftPaneWidth,
-            searchIconData: widget.searchIconData,
-            searchHint: widget.searchHint,
+            appBar: YaruSearchAppBar(
+              searchHint: widget.searchHint,
+              clearSearchIconData: widget.clearSearchIconData,
+              searchController: _searchController,
+              onChanged: _onSearchChanged,
+              onEscape: _onEscape,
+              appBarHeight:
+                  Theme.of(context).appBarTheme.toolbarHeight ?? kToolbarHeight,
+              searchIconData: widget.searchIconData,
+              automaticallyImplyLeading: false,
+            ),
           );
         }
       },

--- a/lib/src/yaru_master_detail_page.dart
+++ b/lib/src/yaru_master_detail_page.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:yaru_widgets/src/yaru_landscape_layout.dart';
 import 'package:yaru_widgets/src/yaru_page_item.dart';
 import 'package:yaru_widgets/src/yaru_portrait_layout.dart';
-import 'package:yaru_widgets/src/yaru_search_app_bar.dart';
 
 class YaruMasterDetailPage extends StatefulWidget {
   /// Creates a basic responsive layout with yaru theme,
@@ -28,6 +27,7 @@ class YaruMasterDetailPage extends StatefulWidget {
     required this.leftPaneWidth,
     this.searchHint,
     this.clearSearchIconData,
+    this.appBar,
   }) : super(key: key);
 
   /// Creates horizontal array of pages.
@@ -51,6 +51,9 @@ class YaruMasterDetailPage extends StatefulWidget {
   /// The hint text given to the search widget.
   final String? searchHint;
 
+  /// An optional custom AppBar for the left pane.
+  final PreferredSizeWidget? appBar;
+
   @override
   _YaruMasterDetailPageState createState() => _YaruMasterDetailPageState();
 }
@@ -58,32 +61,10 @@ class YaruMasterDetailPage extends StatefulWidget {
 class _YaruMasterDetailPageState extends State<YaruMasterDetailPage> {
   var _index = -1;
   var _previousIndex = 0;
-  late List<YaruPageItem> _filteredItems;
-  late TextEditingController _searchController;
-
-  @override
-  void initState() {
-    _filteredItems = <YaruPageItem>[];
-    _searchController = TextEditingController();
-    super.initState();
-  }
 
   void _setIndex(int index) {
     _previousIndex = _index;
     _index = index;
-  }
-
-  void _onEscape() => setState(() {
-        _filteredItems.clear();
-        _searchController.clear();
-      });
-
-  void _onSearchChanged(String value) {
-    setState(() {
-      _filteredItems.clear();
-      _filteredItems.addAll(widget.pageItems.where((element) =>
-          element.title.toLowerCase().contains(value.toLowerCase())));
-    });
   }
 
   @override
@@ -93,40 +74,18 @@ class _YaruMasterDetailPageState extends State<YaruMasterDetailPage> {
         if (constraints.maxWidth < 620) {
           return YaruPortraitLayout(
             selectedIndex: _index,
-            pageItems:
-                _filteredItems.isEmpty ? widget.pageItems : _filteredItems,
+            pageItems: widget.pageItems,
             onSelected: _setIndex,
             previousIconData: widget.previousIconData,
-            appBar: YaruSearchAppBar(
-              searchHint: widget.searchHint,
-              clearSearchIconData: widget.clearSearchIconData,
-              searchController: _searchController,
-              onChanged: _onSearchChanged,
-              onEscape: _onEscape,
-              appBarHeight:
-                  Theme.of(context).appBarTheme.toolbarHeight ?? kToolbarHeight,
-              searchIconData: widget.searchIconData,
-              automaticallyImplyLeading: false,
-            ),
+            appBar: widget.appBar,
           );
         } else {
           return YaruLandscapeLayout(
             selectedIndex: _index == -1 ? _previousIndex : _index,
-            pageItems:
-                _filteredItems.isEmpty ? widget.pageItems : _filteredItems,
+            pageItems: widget.pageItems,
             onSelected: _setIndex,
             leftPaneWidth: widget.leftPaneWidth,
-            appBar: YaruSearchAppBar(
-              searchHint: widget.searchHint,
-              clearSearchIconData: widget.clearSearchIconData,
-              searchController: _searchController,
-              onChanged: _onSearchChanged,
-              onEscape: _onEscape,
-              appBarHeight:
-                  Theme.of(context).appBarTheme.toolbarHeight ?? kToolbarHeight,
-              searchIconData: widget.searchIconData,
-              automaticallyImplyLeading: false,
-            ),
+            appBar: widget.appBar,
           );
         }
       },

--- a/lib/src/yaru_master_detail_page.dart
+++ b/lib/src/yaru_master_detail_page.dart
@@ -78,12 +78,11 @@ class _YaruMasterDetailPageState extends State<YaruMasterDetailPage> {
         _searchController.clear();
       });
 
-  void _onSearchChanged(value) {
+  void _onSearchChanged(String value) {
     setState(() {
       _filteredItems.clear();
-      _filteredItems.addAll(widget.pageItems.where((element) => element.title
-          .toLowerCase()
-          .contains(_searchController.value.text.toLowerCase())));
+      _filteredItems.addAll(widget.pageItems.where((element) =>
+          element.title.toLowerCase().contains(value.toLowerCase())));
     });
   }
 
@@ -98,7 +97,7 @@ class _YaruMasterDetailPageState extends State<YaruMasterDetailPage> {
                 _filteredItems.isEmpty ? widget.pageItems : _filteredItems,
             onSelected: _setIndex,
             previousIconData: widget.previousIconData,
-            yaruSearchAppBar: YaruSearchAppBar(
+            appBar: YaruSearchAppBar(
               searchHint: widget.searchHint,
               clearSearchIconData: widget.clearSearchIconData,
               searchController: _searchController,

--- a/lib/src/yaru_master_detail_page.dart
+++ b/lib/src/yaru_master_detail_page.dart
@@ -63,7 +63,7 @@ class _YaruMasterDetailPageState extends State<YaruMasterDetailPage> {
 
   @override
   void initState() {
-    _filteredItems = <YaruPageItem>[...widget.pageItems];
+    _filteredItems = <YaruPageItem>[];
     _searchController = TextEditingController();
     super.initState();
   }

--- a/lib/src/yaru_portrait_layout.dart
+++ b/lib/src/yaru_portrait_layout.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:yaru_widgets/src/yaru_page_item_list_view.dart';
-import 'package:yaru_widgets/src/yaru_search_app_bar.dart';
 
 import 'yaru_page_item.dart';
 
@@ -77,7 +76,7 @@ class _YaruPortraitLayoutState extends State<YaruPortraitLayout> {
             MaterialPageRoute(
               builder: (context) {
                 return Scaffold(
-                  appBar: widget.appBar ?? AppBar(),
+                  appBar: widget.appBar,
                   body: YaruPageItemListView(
                       selectedIndex: _selectedIndex,
                       onTap: onTap,

--- a/lib/src/yaru_portrait_layout.dart
+++ b/lib/src/yaru_portrait_layout.dart
@@ -11,7 +11,7 @@ class YaruPortraitLayout extends StatefulWidget {
     required this.pageItems,
     required this.onSelected,
     this.previousIconData,
-    this.yaruSearchAppBar,
+    this.appBar,
   }) : super(key: key);
 
   final int selectedIndex;
@@ -19,7 +19,7 @@ class YaruPortraitLayout extends StatefulWidget {
   final ValueChanged<int> onSelected;
   final IconData? previousIconData;
 
-  final YaruSearchAppBar? yaruSearchAppBar;
+  final PreferredSizeWidget? appBar;
 
   @override
   _YaruPortraitLayoutState createState() => _YaruPortraitLayoutState();
@@ -77,7 +77,7 @@ class _YaruPortraitLayoutState extends State<YaruPortraitLayout> {
             MaterialPageRoute(
               builder: (context) {
                 return Scaffold(
-                  appBar: widget.yaruSearchAppBar ?? AppBar(),
+                  appBar: widget.appBar ?? AppBar(),
                   body: YaruPageItemListView(
                       selectedIndex: _selectedIndex,
                       onTap: onTap,

--- a/lib/src/yaru_portrait_layout.dart
+++ b/lib/src/yaru_portrait_layout.dart
@@ -36,10 +36,15 @@ class _YaruPortraitLayoutState extends State<YaruPortraitLayout> {
     super.initState();
   }
 
-  void onTap(int index) {
+  void _onTap(int index) {
     widget.onSelected(index);
     _navigator.push(pageRoute(index));
     setState(() => _selectedIndex = index);
+  }
+
+  void _goBack() {
+    widget.onSelected(-1);
+    _navigator.pop(context);
   }
 
   MaterialPageRoute pageRoute(int index) {
@@ -48,18 +53,27 @@ class _YaruPortraitLayoutState extends State<YaruPortraitLayout> {
       builder: (context) {
         final page = widget.pageItems[_selectedIndex];
         return Scaffold(
-          appBar: AppBar(
-            toolbarHeight: Theme.of(context).appBarTheme.toolbarHeight,
-            title: Text(page.title),
-            leading: InkWell(
-              child: Icon(widget.previousIconData ?? Icons.navigate_before),
-              onTap: () {
-                widget.onSelected(-1);
-                _navigator.pop(context);
-              },
-            ),
-          ),
+          appBar: widget.appBar != null
+              ? AppBar(
+                  toolbarHeight: Theme.of(context).appBarTheme.toolbarHeight,
+                  title: Text(page.title),
+                  leading: InkWell(
+                    child:
+                        Icon(widget.previousIconData ?? Icons.navigate_before),
+                    onTap: _goBack,
+                  ),
+                )
+              : null,
           body: SizedBox(width: width, child: page.builder(context)),
+          floatingActionButton: widget.appBar == null
+              ? FloatingActionButton(
+                  child: Icon(widget.previousIconData),
+                  onPressed: _goBack,
+                )
+              : null,
+          floatingActionButtonLocation: widget.appBar == null
+              ? FloatingActionButtonLocation.miniStartFloat
+              : null,
         );
       },
     );
@@ -79,7 +93,7 @@ class _YaruPortraitLayoutState extends State<YaruPortraitLayout> {
                   appBar: widget.appBar,
                   body: YaruPageItemListView(
                       selectedIndex: _selectedIndex,
-                      onTap: onTap,
+                      onTap: _onTap,
                       pages: widget.pageItems),
                 );
               },

--- a/lib/src/yaru_portrait_layout.dart
+++ b/lib/src/yaru_portrait_layout.dart
@@ -5,22 +5,21 @@ import 'package:yaru_widgets/src/yaru_search_app_bar.dart';
 import 'yaru_page_item.dart';
 
 class YaruPortraitLayout extends StatefulWidget {
-  const YaruPortraitLayout(
-      {Key? key,
-      required this.selectedIndex,
-      required this.pages,
-      required this.onSelected,
-      this.previousIconData,
-      this.searchIconData,
-      this.searchHint})
-      : super(key: key);
+  const YaruPortraitLayout({
+    Key? key,
+    required this.selectedIndex,
+    required this.pageItems,
+    required this.onSelected,
+    this.previousIconData,
+    this.yaruSearchAppBar,
+  }) : super(key: key);
 
   final int selectedIndex;
-  final List<YaruPageItem> pages;
+  final List<YaruPageItem> pageItems;
   final ValueChanged<int> onSelected;
   final IconData? previousIconData;
-  final IconData? searchIconData;
-  final String? searchHint;
+
+  final YaruSearchAppBar? yaruSearchAppBar;
 
   @override
   _YaruPortraitLayoutState createState() => _YaruPortraitLayoutState();
@@ -28,37 +27,27 @@ class YaruPortraitLayout extends StatefulWidget {
 
 class _YaruPortraitLayoutState extends State<YaruPortraitLayout> {
   late int _selectedIndex;
-  late TextEditingController _searchController;
-  final _filteredItems = <YaruPageItem>[];
   final _navigatorKey = GlobalKey<NavigatorState>();
 
   NavigatorState get _navigator => _navigatorKey.currentState!;
 
   @override
   void initState() {
-    _searchController = TextEditingController();
     _selectedIndex = widget.selectedIndex;
     super.initState();
   }
 
   void onTap(int index) {
-    if (_filteredItems.isNotEmpty) {
-      index = widget.pages.indexOf(widget.pages.firstWhere(
-          (pageItem) => pageItem.title == _filteredItems[index].title));
-    }
-
-    _navigator.push(pageRoute(index));
     widget.onSelected(index);
+    _navigator.push(pageRoute(index));
     setState(() => _selectedIndex = index);
-    _searchController.clear();
-    _filteredItems.clear();
   }
 
   MaterialPageRoute pageRoute(int index) {
     final width = MediaQuery.of(context).size.width;
     return MaterialPageRoute(
       builder: (context) {
-        final page = widget.pages[_selectedIndex];
+        final page = widget.pageItems[_selectedIndex];
         return Scaffold(
           appBar: AppBar(
             toolbarHeight: Theme.of(context).appBarTheme.toolbarHeight,
@@ -88,13 +77,11 @@ class _YaruPortraitLayoutState extends State<YaruPortraitLayout> {
             MaterialPageRoute(
               builder: (context) {
                 return Scaffold(
-                  appBar: addSearchBar(),
+                  appBar: widget.yaruSearchAppBar ?? AppBar(),
                   body: YaruPageItemListView(
-                    selectedIndex: _selectedIndex,
-                    onTap: onTap,
-                    pages:
-                        _filteredItems.isEmpty ? widget.pages : _filteredItems,
-                  ),
+                      selectedIndex: _selectedIndex,
+                      onTap: onTap,
+                      pages: widget.pageItems),
                 );
               },
             ),
@@ -102,33 +89,6 @@ class _YaruPortraitLayoutState extends State<YaruPortraitLayout> {
           ];
         },
       ),
-    );
-  }
-
-  YaruSearchAppBar addSearchBar() {
-    return YaruSearchAppBar(
-      searchHint: widget.searchHint,
-      searchController: _searchController,
-      onChanged: (value) {
-        setState(() {
-          _filteredItems.clear();
-          for (YaruPageItem pageItem in widget.pages) {
-            if (pageItem.title
-                .toLowerCase()
-                .contains(_searchController.value.text.toLowerCase())) {
-              _filteredItems.add(pageItem);
-            }
-          }
-        });
-      },
-      onEscape: () => setState(() {
-        _searchController.clear();
-        _filteredItems.clear();
-      }),
-      appBarHeight:
-          Theme.of(context).appBarTheme.toolbarHeight ?? kToolbarHeight,
-      searchIconData: widget.searchIconData,
-      automaticallyImplyLeading: false,
     );
   }
 }

--- a/lib/src/yaru_search_app_bar.dart
+++ b/lib/src/yaru_search_app_bar.dart
@@ -77,13 +77,12 @@ class YaruSearchAppBar extends StatelessWidget implements PreferredSizeWidget {
                     .titleTextStyle
                     ?.copyWith(fontWeight: FontWeight.w200, fontSize: 18),
             decoration: InputDecoration(
-              prefixIcon: Padding(
-                padding: const EdgeInsets.only(left: 28, right: 25, bottom: 7),
-                child: Icon(
-                  searchIconData ?? Icons.search,
-                  color: textColor,
-                ),
+              prefixIcon: Icon(
+                searchIconData ?? Icons.search,
+                color: textColor,
               ),
+              prefixIconConstraints: BoxConstraints.expand(
+                  width: appBarHeight, height: appBarHeight),
               suffixIcon: InkWell(
                 child:
                     Icon(clearSearchIconData ?? Icons.close, color: textColor),
@@ -99,7 +98,7 @@ class YaruSearchAppBar extends StatelessWidget implements PreferredSizeWidget {
             ),
             controller: searchController,
             autofocus: true,
-            onChanged: (value) => onChanged(value),
+            onChanged: onChanged,
           ),
         ),
       ),

--- a/lib/src/yaru_search_app_bar.dart
+++ b/lib/src/yaru_search_app_bar.dart
@@ -12,7 +12,7 @@ class YaruSearchAppBar extends StatelessWidget implements PreferredSizeWidget {
   /// Vertical alignment of the [TextField] will be center.
   const YaruSearchAppBar({
     Key? key,
-    required this.searchController,
+    this.searchController,
     required this.onChanged,
     required this.onEscape,
     required this.automaticallyImplyLeading,
@@ -24,7 +24,7 @@ class YaruSearchAppBar extends StatelessWidget implements PreferredSizeWidget {
   }) : super(key: key);
 
   /// Pass a new [TextEditingController] instance.
-  final TextEditingController searchController;
+  final TextEditingController? searchController;
 
   /// The callback that gets invoked when the value changes in the text field.
   final Function(String value) onChanged;
@@ -44,7 +44,7 @@ class YaruSearchAppBar extends StatelessWidget implements PreferredSizeWidget {
   /// Specifies the [TextStyle]
   final TextStyle? textStyle;
 
-  /// If false, hides the search icon in the [AppBar]
+  /// If false, hides the back icon in the [AppBar]
   final bool automaticallyImplyLeading;
 
   final IconData? clearSearchIconData;
@@ -77,6 +77,7 @@ class YaruSearchAppBar extends StatelessWidget implements PreferredSizeWidget {
                     .titleTextStyle
                     ?.copyWith(fontWeight: FontWeight.w200, fontSize: 18),
             decoration: InputDecoration(
+              contentPadding: const EdgeInsets.only(top: 6),
               prefixIcon: Icon(
                 searchIconData ?? Icons.search,
                 color: textColor,

--- a/lib/src/yaru_search_app_bar.dart
+++ b/lib/src/yaru_search_app_bar.dart
@@ -20,6 +20,7 @@ class YaruSearchAppBar extends StatelessWidget implements PreferredSizeWidget {
     required this.appBarHeight,
     this.textStyle,
     this.searchHint,
+    this.clearSearchIconData,
   }) : super(key: key);
 
   /// Pass a new [TextEditingController] instance.
@@ -46,6 +47,8 @@ class YaruSearchAppBar extends StatelessWidget implements PreferredSizeWidget {
   /// If false, hides the search icon in the [AppBar]
   final bool automaticallyImplyLeading;
 
+  final IconData? clearSearchIconData;
+
   @override
   Widget build(BuildContext context) {
     final textColor = Theme.of(context).appBarTheme.foregroundColor;
@@ -62,38 +65,41 @@ class YaruSearchAppBar extends StatelessWidget implements PreferredSizeWidget {
         focusNode: FocusNode(),
         child: SizedBox(
           height: appBarHeight,
-          child: Padding(
-            padding: const EdgeInsets.only(top: 4),
-            child: TextField(
-              expands: true,
-              maxLines: null,
-              minLines: null,
-              cursorColor: textColor,
-              textAlignVertical: TextAlignVertical.center,
-              style: textStyle ??
-                  Theme.of(context)
-                      .appBarTheme
-                      .titleTextStyle
-                      ?.copyWith(fontWeight: FontWeight.w200, fontSize: 18),
-              decoration: InputDecoration(
-                prefixIcon: Padding(
-                  padding:
-                      const EdgeInsets.only(left: 28, right: 25, bottom: 7),
-                  child: Icon(
-                    searchIconData ?? Icons.search,
-                    color: textColor,
-                  ),
+          child: TextField(
+            expands: true,
+            maxLines: null,
+            minLines: null,
+            cursorColor: textColor,
+            textAlignVertical: TextAlignVertical.center,
+            style: textStyle ??
+                Theme.of(context)
+                    .appBarTheme
+                    .titleTextStyle
+                    ?.copyWith(fontWeight: FontWeight.w200, fontSize: 18),
+            decoration: InputDecoration(
+              prefixIcon: Padding(
+                padding: const EdgeInsets.only(left: 28, right: 25, bottom: 7),
+                child: Icon(
+                  searchIconData ?? Icons.search,
+                  color: textColor,
                 ),
-                hintText: searchHint,
-                enabledBorder: UnderlineInputBorder(
-                    borderSide:
-                        BorderSide(color: Colors.black.withOpacity(0.01))),
-                border: const UnderlineInputBorder(),
               ),
-              controller: searchController,
-              autofocus: true,
-              onChanged: (value) => onChanged(value),
+              suffixIcon: InkWell(
+                child:
+                    Icon(clearSearchIconData ?? Icons.close, color: textColor),
+                onTap: onEscape,
+              ),
+              suffixIconConstraints: BoxConstraints.expand(
+                  width: appBarHeight, height: appBarHeight),
+              hintText: searchHint,
+              enabledBorder: UnderlineInputBorder(
+                  borderSide:
+                      BorderSide(color: Colors.black.withOpacity(0.01))),
+              border: const UnderlineInputBorder(),
             ),
+            controller: searchController,
+            autofocus: true,
+            onChanged: (value) => onChanged(value),
           ),
         ),
       ),


### PR DESCRIPTION
This removes the hardcoded search bar from YaruMasterDetails / Landscape / Portrait layout

If needed everything can be defined top down, for example with a yaru searchbar but any widget is possible now. This will be useful when yaru widgets will be used for other desktop apps, like a file explorer.

This leaves also room for design without appbars if wanted:

![ya](https://user-images.githubusercontent.com/15329494/154127301-0cadb980-8d50-4876-921d-21901113c764.gif)

Closes #85 