### PR TITLE
Bugfix/example carousel page selectable container page image asset path

### DIFF
--- a/example/lib/pages/carousel_page.dart
+++ b/example/lib/pages/carousel_page.dart
@@ -1,6 +1,3 @@
-import 'dart:io';
-
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
@@ -20,15 +17,10 @@ class _CarouselPageState extends State<CarouselPage> {
     return YaruPage(children: [
       YaruCarousel(
         fit: BoxFit.fitHeight,
-        images: kIsWeb
-            ? [
-                for (var i = 0; i < length; i++)
-                  AssetImage('assets/ubuntuhero.jpg'),
-              ]
-            : [
-                for (var i = 0; i < length; i++)
-                  FileImage(File('assets/ubuntuhero.jpg')),
-              ],
+        images: List.generate(
+          length,
+          (_) => AssetImage('assets/ubuntuhero.jpg'),
+        ),
         height: 400,
       ),
       YaruRow(

--- a/example/lib/pages/selectable_container_page.dart
+++ b/example/lib/pages/selectable_container_page.dart
@@ -1,9 +1,6 @@
-import 'dart:io';
-
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:yaru_widgets/yaru_widgets.dart';
 import 'package:yaru_icons/yaru_icons.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
 
 class SelectableContainerPage extends StatefulWidget {
   const SelectableContainerPage({Key? key}) : super(key: key);
@@ -33,28 +30,22 @@ class _SelectableContainerPageState extends State<SelectableContainerPage> {
             YaruSelectableContainer(
               selected: !_isImageSelected,
               onTap: () => setState(() => _isImageSelected = !_isImageSelected),
-              child: kIsWeb
-                  ? Image.asset(
-                      'assets/ubuntuhero.jpg',
-                      filterQuality: FilterQuality.low,
-                      fit: BoxFit.fill,
-                      height: 300,
-                    )
-                  : Image.file(File('assets/ubuntuhero.jpg'),
-                      filterQuality: FilterQuality.low, fit: BoxFit.fill),
+              child: Image.asset(
+                'assets/ubuntuhero.jpg',
+                filterQuality: FilterQuality.low,
+                fit: BoxFit.fill,
+                height: 300,
+              ),
             ),
             YaruSelectableContainer(
               selected: _isImageSelected,
               onTap: () => setState(() => _isImageSelected = !_isImageSelected),
-              child: kIsWeb
-                  ? Image.asset(
-                      'assets/ubuntuhero.jpg',
-                      filterQuality: FilterQuality.low,
-                      fit: BoxFit.fill,
-                      height: 300,
-                    )
-                  : Image.file(File('assets/ubuntuhero.jpg'),
-                      filterQuality: FilterQuality.low, fit: BoxFit.fill),
+              child: Image.asset(
+                'assets/ubuntuhero.jpg',
+                filterQuality: FilterQuality.low,
+                fit: BoxFit.fill,
+                height: 300,
+              ),
             ),
           ],
         ),


### PR DESCRIPTION
When running the example app locally on macos, I noticed that `CarouselPage` and `SelectableContainerPage` threw a `FileSystemException`:

```
Cannot open file, path = 'assets[/ubuntuhero.jpg]()' (OS Error: No such file or directory, errno = 2)
```

![Bildschirmfoto 2022-02-23 um 17 28 05](https://user-images.githubusercontent.com/13286425/155362648-571aeeb4-ef8d-46fb-8f7d-612ad97b7632.png)

By using `AssetImage`, the example is now correctly working locally for me on web and macOS (through IDE or terminal), and when running a web release build on a local server (i.e. `flutter build web --release`, `npx http-server`).

I have not tried the example on Linux, however I would expect that the existing code also would not work.

BTW it may be an idea to add macOS as an example target. I am happy to open this in another PR if you'd like :)