### PR TITLE
Feature/yaru master detail page remove unused variables

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -44,9 +44,6 @@ class _HomeState extends State<Home> {
       home: YaruMasterDetailPage(
         leftPaneWidth: 280,
         previousIconData: YaruIcons.go_previous,
-        searchHint: 'Search...',
-        searchIconData: YaruIcons.search,
-        clearSearchIconData: YaruIcons.window_close,
         pageItems:
             _filteredItems.isNotEmpty ? _filteredItems : examplePageItems,
         appBar: YaruSearchAppBar(

--- a/lib/src/yaru_master_detail_page.dart
+++ b/lib/src/yaru_master_detail_page.dart
@@ -23,10 +23,7 @@ class YaruMasterDetailPage extends StatefulWidget {
     Key? key,
     required this.pageItems,
     this.previousIconData,
-    this.searchIconData,
     required this.leftPaneWidth,
-    this.searchHint,
-    this.clearSearchIconData,
     this.appBar,
   }) : super(key: key);
 
@@ -41,15 +38,6 @@ class YaruMasterDetailPage extends StatefulWidget {
 
   /// Property to specify the previous icon data
   final IconData? previousIconData;
-
-  /// The icon that is given to the search widget.
-  final IconData? searchIconData;
-
-  /// Search icon for search bar.
-  final IconData? clearSearchIconData;
-
-  /// The hint text given to the search widget.
-  final String? searchHint;
 
   /// An optional custom AppBar for the left pane.
   final PreferredSizeWidget? appBar;


### PR DESCRIPTION
While using `YaruMasterDetailPage`, I was a little confused what `searchHint` etc. were for. Then after looking at the code, I realized they are probably leftovers after being extracted to `YaruSearchAppBar` in the past.