### PR TITLE
YaruCarousel: auto hide indicator if child length = 1

### DIFF
--- a/lib/src/yaru_carousel.dart
+++ b/lib/src/yaru_carousel.dart
@@ -87,7 +87,9 @@ class _YaruCarouselState extends State<YaruCarousel> {
     return Column(
       children: [
         _buildCarousel(),
-        ...(widget.placeIndicator ? [_buildPlaceIndicator()] : [])
+        ...(widget.placeIndicator && widget.children.length > 1
+            ? [_buildPlaceIndicator()]
+            : [])
       ],
     );
   }


### PR DESCRIPTION
IMO, having an unique dot is a bit weird:

![Capture d’écran du 2022-05-17 17-50-07](https://user-images.githubusercontent.com/36476595/168854444-0a5eafd5-83d2-4bb5-b260-bf98f5eafa7c.png)

So let hide the indicator if child length = 1.