### PR TITLE
YaruCarousel: use size transform animation

### DIFF
--- a/lib/src/yaru_carousel.dart
+++ b/lib/src/yaru_carousel.dart
@@ -108,7 +108,7 @@ class _YaruCarouselState extends State<YaruCarousel> {
             widget.autoScroll ? const NeverScrollableScrollPhysics() : null,
         onPageChanged: (index) => setState(() => _index = index),
         itemBuilder: (context, index) => AnimatedScale(
-          scale: _index == index ? 1.0 : .9,
+          scale: _index == index ? 1.0 : .95,
           duration: _kAnimationDuration,
           curve: _kAnimationCurve,
           child: Container(

--- a/lib/src/yaru_carousel.dart
+++ b/lib/src/yaru_carousel.dart
@@ -99,28 +99,32 @@ class _YaruCarouselState extends State<YaruCarousel> {
       height: widget.height,
       width: widget.width,
       child: PageView.builder(
-          itemCount: widget.children.length,
-          pageSnapping: true,
-          controller: _pageController,
-          physics:
-              // Disable physic when auto scroll is enable because we cannot
-              // disable the timer when dragging the view
-              widget.autoScroll ? const NeverScrollableScrollPhysics() : null,
-          onPageChanged: (index) => setState(() => _index = index),
-          itemBuilder: (context, index) => AnimatedContainer(
-                duration: _kAnimationDuration,
-                curve: _kAnimationCurve,
-                margin: EdgeInsets.all(index == _index ? 10 : 20),
-                child: _index == index - 1 || _index == index + 1
-                    ? GestureDetector(
-                        behavior: HitTestBehavior.opaque,
-                        onTap: () => _animateToPage(index),
-                        child: IgnorePointer(
-                          child: widget.children[index],
-                        ),
-                      )
-                    : widget.children[index],
-              )),
+        itemCount: widget.children.length,
+        pageSnapping: true,
+        controller: _pageController,
+        physics:
+            // Disable physic when auto scroll is enable because we cannot
+            // disable the timer when dragging the view
+            widget.autoScroll ? const NeverScrollableScrollPhysics() : null,
+        onPageChanged: (index) => setState(() => _index = index),
+        itemBuilder: (context, index) => AnimatedScale(
+          scale: _index == index ? 1.0 : .9,
+          duration: _kAnimationDuration,
+          curve: _kAnimationCurve,
+          child: Container(
+            margin: const EdgeInsets.all(10),
+            child: _index == index - 1 || _index == index + 1
+                ? GestureDetector(
+                    behavior: HitTestBehavior.opaque,
+                    onTap: () => _animateToPage(index),
+                    child: IgnorePointer(
+                      child: widget.children[index],
+                    ),
+                  )
+                : widget.children[index],
+          ),
+        ),
+      ),
     );
   }
 


### PR DESCRIPTION
Use a size transform animation instead of the animated margin property, to avoid weird effect with text child.

**Before:**

https://user-images.githubusercontent.com/36476595/169053393-d89bfffd-bc86-4b95-a4e2-77cf7122df0c.mp4

**After:**

https://user-images.githubusercontent.com/36476595/169053460-e61aa403-5b6d-4d2b-8fe6-74e1d76d9686.mp4