### PR TITLE
YaruCarousel: fix text indicator

### DIFF
--- a/lib/src/yaru_carousel.dart
+++ b/lib/src/yaru_carousel.dart
@@ -178,7 +178,7 @@ class _YaruCarouselState extends State<YaruCarousel> {
           Padding(
             padding: const EdgeInsets.all(8.0),
             child: Text(
-              '$_index/${widget.children.length}',
+              '${_index + 1}/${widget.children.length}',
               style: Theme.of(context).textTheme.caption,
             ),
           )


### PR DESCRIPTION
**Before:**

The first page show 0 and the last one indicate the length - 1.

![Capture d’écran du 2022-05-23 23-27-24](https://user-images.githubusercontent.com/36476595/169908823-beaee5a8-791a-4e11-b7bc-7b7e6d7f56d8.png)

**After:**

![Capture d’écran du 2022-05-23 23-27-40](https://user-images.githubusercontent.com/36476595/169908829-8b0a4957-898e-41dc-acc7-10007863e6f1.png)
