### PR TITLE
YaruCarousel: use grey for unselected dots

### DIFF
--- a/lib/src/yaru_carousel.dart
+++ b/lib/src/yaru_carousel.dart
@@ -181,7 +181,7 @@ class _YaruCarouselState extends State<YaruCarousel> {
               decoration: BoxDecoration(
                   color: _index == index
                       ? Theme.of(context).colorScheme.primary
-                      : Theme.of(context).colorScheme.primary.withOpacity(0.3),
+                      : Theme.of(context).colorScheme.onSurface.withOpacity(.3),
                   shape: BoxShape.circle),
             ),
           ),


### PR DESCRIPTION
**Before:**

![Capture d’écran du 2022-05-27 14-05-05](https://user-images.githubusercontent.com/36476595/170696076-e405ef5d-cdad-417a-b2de-b83e4adbfed5.png)

**After:**

![Capture d’écran du 2022-05-27 13-52-28](https://user-images.githubusercontent.com/36476595/170696072-5b9c6d1d-ec42-416a-b227-3d3c5a988c18.png)
