### PR TITLE
YaruDialogTitle: fix for material3

### DIFF
--- a/lib/src/yaru_dialog_title.dart
+++ b/lib/src/yaru_dialog_title.dart
@@ -70,11 +70,21 @@ class YaruDialogTitle extends StatelessWidget {
             ],
           ),
         ),
-        IconButton(
-            visualDensity: VisualDensity.compact,
-            onPressed: onPressed ?? () => Navigator.pop(context),
-            splashRadius: 16,
-            icon: Icon(closeIconData ?? Icons.close))
+        Padding(
+          padding: const EdgeInsets.all(5.0),
+          child: SizedBox(
+            height: 30,
+            width: 30,
+            child: Material(
+              borderRadius: BorderRadius.circular(20),
+              child: InkWell(
+                borderRadius: BorderRadius.circular(20),
+                onTap: onPressed ?? () => Navigator.pop(context),
+                child: Icon(closeIconData ?? Icons.close),
+              ),
+            ),
+          ),
+        )
       ],
     );
   }


### PR DESCRIPTION
They changed icon buttons to look like a pill rather than a disk. This replaces the icon button with an inkwell to be independent of material3

| Before | After |
| --- | --- |
| ![grafik](https://user-images.githubusercontent.com/15329494/173196360-dd75b978-38a3-4b28-849e-1b0bfedd3ab4.png) | ![grafik](https://user-images.githubusercontent.com/15329494/173196315-c9e58602-f76f-479f-8316-59b6f42c6d01.png) |