### PR TITLE
Add new YaruPageItemTitle widget

### DIFF
--- a/example/lib/example_page_items.dart
+++ b/example/lib/example_page_items.dart
@@ -23,7 +23,7 @@ const _lorem =
 
 final examplePageItems = <YaruPageItem>[
   YaruPageItem(
-      titleBuilder: (context) => Text('YaruRow'),
+      titleBuilder: (context) => YaruPageItemTitle.text('YaruRow'),
       iconData: YaruIcons.format_unordered_list,
       builder: (_) => YaruPage(children: [RowList()]),
       itemWidget: SizedBox(
@@ -31,12 +31,12 @@ final examplePageItems = <YaruPageItem>[
         child: YaruCircularProgressIndicator(strokeWidth: 2),
       )),
   YaruPageItem(
-    titleBuilder: (context) => Text('YaruExtraOptionRow'),
+    titleBuilder: (context) => YaruPageItemTitle.text('YaruExtraOptionRow'),
     iconData: YaruIcons.settings_filled,
     builder: (_) => ExtraOptionRowPage(),
   ),
   YaruPageItem(
-    titleBuilder: (context) => Text('YaruProgressIndicator'),
+    titleBuilder: (context) => YaruPageItemTitle.text('YaruProgressIndicator'),
     iconData: YaruIcons.download,
     builder: (_) => YaruPage(
       children: [
@@ -64,17 +64,18 @@ final examplePageItems = <YaruPageItem>[
     ),
   ),
   YaruPageItem(
-    titleBuilder: (context) => Text('YaruSelectableContainer'),
+    titleBuilder: (context) =>
+        YaruPageItemTitle.text('YaruSelectableContainer'),
     iconData: YaruIcons.selection,
     builder: (_) => SelectableContainerPage(),
   ),
   YaruPageItem(
-    titleBuilder: (context) => Text('YaruOptionButton'),
+    titleBuilder: (context) => YaruPageItemTitle.text('YaruOptionButton'),
     iconData: YaruIcons.settings,
     builder: (_) => YaruPage(children: [OptionButtonList()]),
   ),
   YaruPageItem(
-    titleBuilder: (context) => Text('YaruSearchAppBar'),
+    titleBuilder: (context) => YaruPageItemTitle.text('YaruSearchAppBar'),
     iconData: YaruIcons.folder_search,
     builder: (_) => YaruPage(
       children: [
@@ -91,12 +92,12 @@ final examplePageItems = <YaruPageItem>[
     ),
   ),
   YaruPageItem(
-    titleBuilder: (context) => Text('YaruSection'),
+    titleBuilder: (context) => YaruPageItemTitle.text('YaruSection'),
     iconData: YaruIcons.window,
     builder: (_) => SectionPage(),
   ),
   YaruPageItem(
-    titleBuilder: (context) => Text('YaruSingleInfoRow'),
+    titleBuilder: (context) => YaruPageItemTitle.text('YaruSingleInfoRow'),
     iconData: YaruIcons.format_ordered_list,
     builder: (_) => YaruPage(
       children: [
@@ -114,44 +115,44 @@ final examplePageItems = <YaruPageItem>[
     ),
   ),
   YaruPageItem(
-    titleBuilder: (context) => Text('YaruSliderRow'),
+    titleBuilder: (context) => YaruPageItemTitle.text('YaruSliderRow'),
     iconData: YaruIcons.speaker_volume_medium,
     builder: (_) => SliderPage(),
   ),
   YaruPageItem(
-    titleBuilder: (context) => Text('YaruSwitchRow'),
+    titleBuilder: (context) => YaruPageItemTitle.text('YaruSwitchRow'),
     iconData: YaruIcons.radio_button_filled,
     builder: (_) => SwitchRowPage(),
   ),
   YaruPageItem(
-    titleBuilder: (context) => Text('YaruToggleButtonsRow'),
+    titleBuilder: (context) => YaruPageItemTitle.text('YaruToggleButtonsRow'),
     iconData: YaruIcons.object_flip_horizontal,
     builder: (_) => ToggleButtonsRowPage(),
   ),
   YaruPageItem(
-      titleBuilder: (context) => Text('YaruCheckboxRow'),
+      titleBuilder: (context) => YaruPageItemTitle.text('YaruCheckboxRow'),
       iconData: YaruIcons.checkbox_button_checked,
       builder: (_) => CheckBoxRowPage(),
       searchMatches: CheckBoxRowPage.searchMatches),
   YaruPageItem(
-      titleBuilder: (context) => Text('YaruTabbedPage'),
+      titleBuilder: (context) => YaruPageItemTitle.text('YaruTabbedPage'),
       builder: (_) => TabbedPagePage(),
       iconData: YaruIcons.tab_new),
   YaruPageItem(
-      titleBuilder: (context) => Text('Color picker button'),
+      titleBuilder: (context) => YaruPageItemTitle.text('Color picker button'),
       builder: (_) => ColorPickerPage(),
       iconData: YaruIcons.color_select),
   YaruPageItem(
-      titleBuilder: (context) => Text('YaruCarousel'),
+      titleBuilder: (context) => YaruPageItemTitle.text('YaruCarousel'),
       builder: (_) => CarouselPage(),
       iconData: YaruIcons.refresh),
   YaruPageItem(
-    titleBuilder: (context) => Text('YaruColorDisk'),
+    titleBuilder: (context) => YaruPageItemTitle.text('YaruColorDisk'),
     builder: (context) => ColorDiskPage(),
     iconData: YaruIcons.color_select,
   ),
   YaruPageItem(
-    titleBuilder: (context) => Text('YaruExpandable'),
+    titleBuilder: (context) => YaruPageItemTitle.text('YaruExpandable'),
     iconData: YaruIcons.pan_down,
     builder: (_) => YaruPage(
       children: [
@@ -181,17 +182,17 @@ final examplePageItems = <YaruPageItem>[
     ),
   ),
   YaruPageItem(
-    titleBuilder: (context) => Text('YaruRoundToggleButton'),
+    titleBuilder: (context) => YaruPageItemTitle.text('YaruRoundToggleButton'),
     builder: (context) => RoundToggleButtonPage(),
     iconData: YaruIcons.app_grid,
   ),
   YaruPageItem(
-    titleBuilder: (context) => Text('YaruDraggable'),
+    titleBuilder: (context) => YaruPageItemTitle.text('YaruDraggable'),
     builder: (context) => DraggablePage(),
     iconData: YaruIcons.drag_handle,
   ),
   YaruPageItem(
-    titleBuilder: (context) => Text('YaruBanner'),
+    titleBuilder: (context) => YaruPageItemTitle.text('YaruBanner'),
     builder: (context) => BannerPage(),
     iconData: YaruIcons.image,
   )

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -47,7 +47,7 @@ class _HomeState extends State<Home> {
   @override
   Widget build(BuildContext context) {
     final configItem = YaruPageItem(
-      titleBuilder: (context) => Text('Layout'),
+      titleBuilder: (context) => YaruPageItemTitle.text('Layout'),
       builder: (_) => YaruPage(children: [
         YaruSwitchRow(
           trailingWidget: Text('Compact mode'),

--- a/lib/src/yaru_page_item.dart
+++ b/lib/src/yaru_page_item.dart
@@ -10,7 +10,10 @@ class YaruPageItem {
     this.itemWidget,
     this.selectedItemWidget,
   });
+
+  /// We recommend to use [YaruPageItemTitle] here to avoid line wrap
   final WidgetBuilder titleBuilder;
+
   final WidgetBuilder builder;
   final IconData iconData;
   final Widget? itemWidget;

--- a/lib/src/yaru_page_item_title.dart
+++ b/lib/src/yaru_page_item_title.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/widgets.dart';
+
+/// This is an optional widget, which avoid line wrap in sidebar
+/// It alters the children text style with: maxLines=1 and overflow=TextOverflow.ellipsis
+/// This allow to have the same look as the nautilus sidebar when horizontal space becomes too small
+class YaruPageItemTitle extends StatelessWidget {
+  const YaruPageItemTitle(this.child, {Key? key}) : super(key: key);
+
+  /// Shortcut to directly wrap a string into a [Text] widget
+  YaruPageItemTitle.text(String text, {Key? key})
+      : child = Text(text),
+        super(key: key);
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return DefaultTextStyle.merge(
+      child: child,
+      maxLines: 1,
+      overflow: TextOverflow.ellipsis,
+    );
+  }
+}

--- a/lib/yaru_widgets.dart
+++ b/lib/yaru_widgets.dart
@@ -19,6 +19,7 @@ export 'src/yaru_narrow_layout.dart';
 export 'src/yaru_option_button.dart';
 export 'src/yaru_page.dart';
 export 'src/yaru_page_item.dart';
+export 'src/yaru_page_item_title.dart';
 export 'src/yaru_round_icon_button.dart';
 export 'src/yaru_round_toggle_button.dart';
 export 'src/yaru_row.dart';


### PR DESCRIPTION
Add a new `YaruPageItemTitle` widget, which alter the current text style with:
- `maxLines`: **1**
- `overflow`: `TextOverflow.ellipsis`

You can pass a child widget, or directly a string with the `YaruPageItemTitle.text` constructor.

**Before:**

![Capture d’écran du 2022-08-10 17-52-05](https://user-images.githubusercontent.com/36476595/183954217-ff89c1e8-879c-463d-b967-dc01b8134848.png)

**After:**

![Capture d’écran du 2022-08-10 17-51-45](https://user-images.githubusercontent.com/36476595/183954207-2c022a8e-a804-4bbd-8409-8e301159328e.png)

Closes #174 