### PR TITLE
YaruOptionButton: replace iconData with a child widget

### DIFF
--- a/example/lib/pages/carousel_page.dart
+++ b/example/lib/pages/carousel_page.dart
@@ -40,7 +40,7 @@ class _CarouselPageState extends State<CarouselPage> {
                   onPressed: () => setState(() {
                         length++;
                       }),
-                  iconData: YaruIcons.plus),
+                  child: Icon(YaruIcons.plus)),
               SizedBox(
                 width: 10,
               ),
@@ -48,7 +48,7 @@ class _CarouselPageState extends State<CarouselPage> {
                   onPressed: () => setState(() {
                         length >= 2 ? length-- : length = length;
                       }),
-                  iconData: YaruIcons.minus)
+                  child: Icon(YaruIcons.minus))
             ],
           ),
           enabled: true)

--- a/example/lib/widgets/option_button_list.dart
+++ b/example/lib/widgets/option_button_list.dart
@@ -10,22 +10,22 @@ class OptionButtonList extends StatelessWidget {
     return Row(
       children: [
         YaruOptionButton(
-          iconData: YaruIcons.search,
           onPressed: () {},
+          child: Icon(YaruIcons.search),
         ),
         const SizedBox(
           width: 10.0,
         ),
         YaruOptionButton(
-          iconData: YaruIcons.audio,
           onPressed: () {},
+          child: Icon(YaruIcons.audio),
         ),
         const SizedBox(
           width: 10.0,
         ),
         YaruOptionButton(
-          iconData: YaruIcons.address_book,
           onPressed: () {},
+          child: Icon(YaruIcons.address_book),
         ),
       ],
     );

--- a/lib/src/controls/yaru_option_button.dart
+++ b/lib/src/controls/yaru_option_button.dart
@@ -6,32 +6,37 @@ class YaruOptionButton extends StatelessWidget {
   ///
   /// for example:
   /// ```dart
-  ///  YaruOptionButton(
-  ///           iconData: YaruIcons.search,
-  ///           onPressed: () {},
-  ///         ),
+  /// YaruOptionButton(
+  ///   onPressed: () {},
+  ///   icon: Icon(YaruIcons.search),
+  /// ),
   /// ```
   const YaruOptionButton({
     Key? key,
     required this.onPressed,
-    required this.iconData,
+    required this.child,
   }) : super(key: key);
 
   /// Callback that gets invoked when the button is clicked.
   final VoidCallback? onPressed;
 
-  /// The [IconData] is place as a child of [OutlinedButton].
-  final IconData iconData;
+  /// The [Widget] is placed as a child of [OutlinedButton].
+  final Widget child;
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      width: 40,
-      height: 40,
-      child: OutlinedButton(
-        style: OutlinedButton.styleFrom(padding: const EdgeInsets.all(0)),
-        onPressed: onPressed,
-        child: Icon(iconData),
+    return OutlinedButton(
+      style: OutlinedButton.styleFrom(
+        minimumSize: const Size(40, 40),
+        maximumSize: const Size(40, 40),
+        padding: const EdgeInsets.all(0),
+      ),
+      onPressed: onPressed,
+      child: IconTheme.merge(
+        data: const IconThemeData(
+          size: 24,
+        ),
+        child: child,
       ),
     );
   }

--- a/lib/src/pages/rows/yaru_extra_option_row.dart
+++ b/lib/src/pages/rows/yaru_extra_option_row.dart
@@ -119,7 +119,7 @@ class YaruExtraOptionRow extends StatelessWidget {
           const SizedBox(width: 8.0),
           YaruOptionButton(
             onPressed: enabled ? onPressed : null,
-            iconData: iconData,
+            child: Icon(iconData),
           ),
         ],
       ),

--- a/test/controls/yaru_options_button_test.dart
+++ b/test/controls/yaru_options_button_test.dart
@@ -9,7 +9,7 @@ void main() {
         home: Scaffold(
           body: YaruOptionButton(
             onPressed: () {},
-            iconData: const IconData(0),
+            child: const Icon(Icons.flutter_dash),
           ),
         ),
       ),


### PR DESCRIPTION
Allow passing an arbitrary widget without limiting it to an Icon, and set the desired icon size via IconTheme. This allows passing an SVG or wrapping the icon with a badge, for example.