### PR TITLE
Yaru*Row: remove the width property

### DIFF
--- a/lib/src/pages/rows/yaru_extra_option_row.dart
+++ b/lib/src/pages/rows/yaru_extra_option_row.dart
@@ -13,7 +13,6 @@ class YaruExtraOptionRow extends StatelessWidget {
     required this.onChanged,
     required this.onPressed,
     required this.iconData,
-    this.width,
     this.padding = const EdgeInsets.all(8.0),
     this.mainAxisAlignment = MainAxisAlignment.spaceBetween,
     this.mainAxisSize = MainAxisSize.max,
@@ -72,9 +71,6 @@ class YaruExtraOptionRow extends StatelessWidget {
   /// IconData for the [YaruOptionButton].
   final IconData iconData;
 
-  /// Optional width passed to [YaruRow]
-  final double? width;
-
   /// The padding [EdgeInsets] which defaults to `EdgeInsets.all(8.0)`.
   final EdgeInsets padding;
 
@@ -100,7 +96,6 @@ class YaruExtraOptionRow extends StatelessWidget {
   Widget build(BuildContext context) {
     final enabled = this.enabled && value != null;
     return YaruRow(
-      width: width,
       enabled: enabled,
       title: Text(actionLabel),
       subtitle: actionDescription != null ? Text(actionDescription!) : null,

--- a/lib/src/pages/rows/yaru_row.dart
+++ b/lib/src/pages/rows/yaru_row.dart
@@ -18,7 +18,6 @@ class YaruRow extends StatelessWidget {
     this.subtitle,
     this.trailing,
     this.enabled = true,
-    this.width,
     this.padding = const EdgeInsets.all(8.0),
     this.mainAxisAlignment = MainAxisAlignment.spaceBetween,
     this.mainAxisSize = MainAxisSize.max,
@@ -45,9 +44,6 @@ class YaruRow extends StatelessWidget {
 
   /// Whether or not we can interact with the widget
   final bool enabled;
-
-  /// The `width` of the [Widget], by default it will be 500.
-  final double? width;
 
   /// The padding [EdgeInsets] which defaults to `EdgeInsets.all(8.0)`.
   final EdgeInsets padding;
@@ -78,43 +74,40 @@ class YaruRow extends StatelessWidget {
             ? Theme.of(context).textTheme.bodyLarge!.color
             : Theme.of(context).disabledColor,
       ),
-      child: SizedBox(
-        width: width,
-        child: Padding(
-          padding: padding,
-          child: Row(
-            mainAxisAlignment: mainAxisAlignment,
-            mainAxisSize: mainAxisSize,
-            crossAxisAlignment: crossAxisAlignment,
-            textDirection: textDirection,
-            verticalDirection: verticalDirection,
-            textBaseline: textBaseline,
-            children: [
-              if (leading != null) ...[leading!, const SizedBox(width: 8)],
-              Expanded(
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    title,
-                    if (subtitle != null)
-                      Padding(
-                        padding: const EdgeInsets.only(top: 4.0),
-                        child: DefaultTextStyle(
-                          style: enabled
-                              ? Theme.of(context).textTheme.bodySmall!
-                              : Theme.of(context).textTheme.bodySmall!.copyWith(
-                                    color: Theme.of(context).disabledColor,
-                                  ),
-                          child: subtitle!,
-                        ),
+      child: Padding(
+        padding: padding,
+        child: Row(
+          mainAxisAlignment: mainAxisAlignment,
+          mainAxisSize: mainAxisSize,
+          crossAxisAlignment: crossAxisAlignment,
+          textDirection: textDirection,
+          verticalDirection: verticalDirection,
+          textBaseline: textBaseline,
+          children: [
+            if (leading != null) ...[leading!, const SizedBox(width: 8)],
+            Expanded(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  title,
+                  if (subtitle != null)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 4.0),
+                      child: DefaultTextStyle(
+                        style: enabled
+                            ? Theme.of(context).textTheme.bodySmall!
+                            : Theme.of(context).textTheme.bodySmall!.copyWith(
+                                  color: Theme.of(context).disabledColor,
+                                ),
+                        child: subtitle!,
                       ),
-                  ],
-                ),
+                    ),
+                ],
               ),
-              if (trailing != null) ...[const SizedBox(width: 8), trailing!],
-            ],
-          ),
+            ),
+            if (trailing != null) ...[const SizedBox(width: 8), trailing!],
+          ],
         ),
       ),
     );

--- a/lib/src/pages/rows/yaru_single_info_row.dart
+++ b/lib/src/pages/rows/yaru_single_info_row.dart
@@ -18,7 +18,6 @@ class YaruSingleInfoRow extends StatelessWidget {
     super.key,
     required this.infoLabel,
     required this.infoValue,
-    this.width,
     this.padding = const EdgeInsets.all(8.0),
     this.mainAxisAlignment = MainAxisAlignment.spaceBetween,
     this.mainAxisSize = MainAxisSize.max,
@@ -37,9 +36,6 @@ class YaruSingleInfoRow extends StatelessWidget {
   ///
   /// Default color of the text will be [Theme.of(context).colorScheme.onSurface.withAlpha(150)].
   final String infoValue;
-
-  /// Optional width passed to [YaruRow]
-  final double? width;
 
   /// The padding [EdgeInsets] which defaults to `EdgeInsets.all(8.0)`.
   final EdgeInsets padding;
@@ -65,7 +61,6 @@ class YaruSingleInfoRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return YaruRow(
-      width: width,
       enabled: true,
       mainAxisAlignment: mainAxisAlignment,
       mainAxisSize: mainAxisSize,

--- a/lib/src/pages/rows/yaru_slider_row.dart
+++ b/lib/src/pages/rows/yaru_slider_row.dart
@@ -34,7 +34,6 @@ class YaruSliderRow extends StatelessWidget {
     this.showValue = true,
     this.fractionDigits = 0,
     required this.onChanged,
-    this.width,
     this.padding = const EdgeInsets.all(8.0),
     this.mainAxisAlignment = MainAxisAlignment.spaceBetween,
     this.mainAxisSize = MainAxisSize.max,
@@ -78,9 +77,6 @@ class YaruSliderRow extends StatelessWidget {
   /// Function run when the slider changes its value
   final Function(double) onChanged;
 
-  /// Optional width passed to [YaruRow]
-  final double? width;
-
   /// The padding [EdgeInsets] which defaults to `EdgeInsets.all(8.0)`.
   final EdgeInsets padding;
 
@@ -109,7 +105,6 @@ class YaruSliderRow extends StatelessWidget {
     final enabled = this.enabled && value != null;
 
     return YaruRow(
-      width: width,
       enabled: enabled,
       title: Text(actionLabel),
       subtitle: actionDescription != null ? Text(actionDescription!) : null,

--- a/lib/src/pages/rows/yaru_switch_row.dart
+++ b/lib/src/pages/rows/yaru_switch_row.dart
@@ -24,7 +24,6 @@ class YaruSwitchRow extends StatelessWidget {
     this.actionDescription,
     required this.value,
     required this.onChanged,
-    this.width,
     this.padding = const EdgeInsets.all(8.0),
     this.mainAxisAlignment = MainAxisAlignment.spaceBetween,
     this.mainAxisSize = MainAxisSize.max,
@@ -48,9 +47,6 @@ class YaruSwitchRow extends StatelessWidget {
 
   /// The callback that  gets invoked when the [Switch] value changes.
   final Function(bool) onChanged;
-
-  /// Optional width passed to [YaruRow]
-  final double? width;
 
   /// The padding [EdgeInsets] which defaults to `EdgeInsets.all(8.0)`.
   final EdgeInsets padding;
@@ -78,7 +74,6 @@ class YaruSwitchRow extends StatelessWidget {
     final enabled = this.enabled && value != null;
 
     return YaruRow(
-      width: width,
       enabled: enabled,
       title: trailingWidget,
       subtitle: actionDescription != null ? Text(actionDescription!) : null,

--- a/lib/src/pages/rows/yaru_toggle_buttons_row.dart
+++ b/lib/src/pages/rows/yaru_toggle_buttons_row.dart
@@ -37,7 +37,6 @@ class YaruToggleButtonsRow extends StatelessWidget {
     required this.labels,
     required this.selectedValues,
     required this.onPressed,
-    this.width,
     this.padding = const EdgeInsets.all(8.0),
     this.mainAxisAlignment = MainAxisAlignment.spaceBetween,
     this.mainAxisSize = MainAxisSize.max,
@@ -81,9 +80,6 @@ class YaruToggleButtonsRow extends StatelessWidget {
   /// When the callback is null, all toggle buttons will be disabled.
   final Function(int) onPressed;
 
-  /// Optional width passed to [YaruRow]
-  final double? width;
-
   /// The padding [EdgeInsets] which defaults to `EdgeInsets.all(8.0)`.
   final EdgeInsets padding;
 
@@ -110,7 +106,6 @@ class YaruToggleButtonsRow extends StatelessWidget {
     final enabled = this.enabled && selectedValues != null;
 
     return YaruRow(
-      width: width,
       enabled: enabled,
       title: Text(actionLabel),
       subtitle: actionDescription != null ? Text(actionDescription!) : null,


### PR DESCRIPTION
ListTile doesn't have such property either. In the settings app, there are only a handful of cases where the width property is used. Often it can be set for the entire section/column/list instead of each individual tile.