### PR TITLE
Add Tooltips (and so Semantics) to layouts navigation

### DIFF
--- a/example/lib/example_page_items.dart
+++ b/example/lib/example_page_items.dart
@@ -15,66 +15,65 @@ import 'pages/tabbed_page_page.dart';
 import 'pages/tile_page.dart';
 
 final examplePageItems = <YaruPageItem>[
-  YaruPageItem(
-    titleBuilder: (context) => YaruPageItemTitle.text('YaruBanner'),
+  YaruPageItem.titleFromLabel(
+    label: 'YaruBanner',
     builder: (context) => const BannerPage(),
     iconBuilder: (context, selected) => selected
         ? const Icon(YaruIcons.image_filled)
         : const Icon(YaruIcons.image),
   ),
-  YaruPageItem(
-    titleBuilder: (context) => YaruPageItemTitle.text('YaruCarousel'),
+  YaruPageItem.titleFromLabel(
+    label: 'YaruCarousel',
     builder: (_) => const CarouselPage(),
     iconBuilder: (context, selected) => const Icon(YaruIcons.refresh),
   ),
-  YaruPageItem(
-    titleBuilder: (context) => YaruPageItemTitle.text('YaruColorDisk'),
+  YaruPageItem.titleFromLabel(
+    label: 'YaruColorDisk',
     builder: (context) => const ColorDiskPage(),
     iconBuilder: (context, selected) => const Icon(YaruIcons.color_select),
   ),
-  YaruPageItem(
-    titleBuilder: (context) => YaruPageItemTitle.text('YaruDraggable'),
+  YaruPageItem.titleFromLabel(
+    label: 'YaruDraggable',
     builder: (context) => const DraggablePage(),
     iconBuilder: (context, selected) => const Icon(YaruIcons.drag_handle),
   ),
-  YaruPageItem(
-    titleBuilder: (context) => YaruPageItemTitle.text('YaruExpandable'),
+  YaruPageItem.titleFromLabel(
+    label: 'YaruExpandable',
     iconBuilder: (context, selected) => const Icon(YaruIcons.pan_down),
     builder: (_) => const ExpandablePage(),
   ),
-  YaruPageItem(
-    titleBuilder: (context) => YaruPageItemTitle.text('YaruProgressIndicator'),
+  YaruPageItem.titleFromLabel(
+    label: 'YaruProgressIndicator',
     iconBuilder: (context, selected) => const Icon(YaruIcons.download),
     builder: (_) => const ProgressIndicatorPage(),
   ),
-  YaruPageItem(
-    titleBuilder: (context) => YaruPageItemTitle.text('YaruOptionButton'),
+  YaruPageItem.titleFromLabel(
+    label: 'YaruOptionButton',
     iconBuilder: (context, selected) => const Icon(YaruIcons.settings),
     builder: (_) => const YaruPage(children: [OptionButtonPage()]),
   ),
-  YaruPageItem(
-    titleBuilder: (context) => YaruPageItemTitle.text('YaruRoundToggleButton'),
+  YaruPageItem.titleFromLabel(
+    label: 'YaruRoundToggleButton',
     builder: (context) => const RoundToggleButtonPage(),
     iconBuilder: (context, selected) => const Icon(YaruIcons.app_grid),
   ),
-  YaruPageItem(
-    titleBuilder: (context) => YaruPageItemTitle.text('YaruSection'),
+  YaruPageItem.titleFromLabel(
+    label: 'YaruSection',
     iconBuilder: (context, selected) => const Icon(YaruIcons.window),
     builder: (_) => const SectionPage(),
   ),
-  YaruPageItem(
-    titleBuilder: (context) =>
-        YaruPageItemTitle.text('YaruSelectableContainer'),
+  YaruPageItem.titleFromLabel(
+    label: 'YaruSelectableContainer',
     iconBuilder: (context, selected) => const Icon(YaruIcons.selection),
     builder: (_) => const SelectableContainerPage(),
   ),
-  YaruPageItem(
-    titleBuilder: (context) => YaruPageItemTitle.text('YaruTabbedPage'),
+  YaruPageItem.titleFromLabel(
+    label: 'YaruTabbedPage',
     builder: (_) => const TabbedPagePage(),
     iconBuilder: (context, selected) => const Icon(YaruIcons.tab_new),
   ),
-  YaruPageItem(
-    titleBuilder: (context) => YaruPageItemTitle.text('YaruTile'),
+  YaruPageItem.titleFromLabel(
+    label: 'YaruTile',
     iconBuilder: (context, selected) =>
         const Icon(YaruIcons.format_unordered_list),
     builder: (_) => const TilePage(),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -32,8 +32,8 @@ class _HomeState extends State<Home> {
 
   @override
   Widget build(BuildContext context) {
-    final configItem = YaruPageItem(
-      titleBuilder: (context) => YaruPageItemTitle.text('Layout'),
+    final configItem = YaruPageItem.titleFromLabel(
+      label: 'Layout',
       builder: (_) => YaruPage(
         children: [
           YaruTile(

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -3,3 +3,4 @@ const kDefaultDialogTitlePadding = 0.0;
 const kDefaultPageWidth = 500.0;
 const kDefaultContainerRadius = 8.0;
 const kDefaultButtonRadius = 6.0;
+const kWaitTooltipDuration = Duration(milliseconds: 500);

--- a/lib/src/pages/layouts/yaru_navigation_rail.dart
+++ b/lib/src/pages/layouts/yaru_navigation_rail.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../../../yaru_widgets.dart';
+import '../../constants.dart';
 
 /// Defines the look of a [YaruNavigationRail]
 enum YaruNavigationRailStyle {
@@ -104,32 +105,34 @@ class _YaruNavigationRailItemState extends State<_YaruNavigationRailItem> {
   @override
   Widget build(BuildContext context) {
     return _buildSizedContainer(
-      Material(
-        child: InkWell(
-          onTap: () {
-            if (widget.onDestinationSelected != null) {
-              widget.onDestinationSelected!.call(widget.index);
-            }
-          },
-          child: Center(
-            child: Padding(
-              padding: EdgeInsets.symmetric(
-                vertical:
-                    widget.style == YaruNavigationRailStyle.labelledExtended
-                        ? 10
-                        : 5,
-                horizontal:
-                    widget.style == YaruNavigationRailStyle.labelledExtended
-                        ? 8
-                        : 5,
+      _buildSemanticContainer(
+        Material(
+          child: InkWell(
+            onTap: () {
+              if (widget.onDestinationSelected != null) {
+                widget.onDestinationSelected!.call(widget.index);
+              }
+            },
+            child: Center(
+              child: Padding(
+                padding: EdgeInsets.symmetric(
+                  vertical:
+                      widget.style == YaruNavigationRailStyle.labelledExtended
+                          ? 10
+                          : 5,
+                  horizontal:
+                      widget.style == YaruNavigationRailStyle.labelledExtended
+                          ? 8
+                          : 5,
+                ),
+                child: _buildColumnOrRow([
+                  _buildIcon(context),
+                  if (widget.style != YaruNavigationRailStyle.compact) ...[
+                    _buildGap(),
+                    _buildLabel(context),
+                  ]
+                ]),
               ),
-              child: _buildColumnOrRow([
-                _buildIcon(context),
-                if (widget.style != YaruNavigationRailStyle.compact) ...[
-                  _buildGap(),
-                  _buildLabel(context),
-                ]
-              ]),
             ),
           ),
         ),
@@ -166,6 +169,14 @@ class _YaruNavigationRailItemState extends State<_YaruNavigationRailItem> {
           child: child,
         ),
       ),
+    );
+  }
+
+  Widget _buildSemanticContainer(Widget child) {
+    return Tooltip(
+      waitDuration: kWaitTooltipDuration,
+      message: widget.destination.label,
+      child: child,
     );
   }
 

--- a/lib/src/pages/layouts/yaru_page_item.dart
+++ b/lib/src/pages/layouts/yaru_page_item.dart
@@ -1,15 +1,27 @@
 import 'package:flutter/widgets.dart';
+import 'yaru_page_item_title.dart';
 
 class YaruPageItem {
   const YaruPageItem({
     required this.titleBuilder,
+    required this.label,
     required this.builder,
     required this.iconBuilder,
     this.onTap,
   });
 
+  /// Shortcut to directly build [titleBuilder] with the [label] string into a [YaruPageItemTitle]
+  YaruPageItem.titleFromLabel({
+    required this.label,
+    required this.builder,
+    required this.iconBuilder,
+    this.onTap,
+  }) : titleBuilder = ((context) => YaruPageItemTitle.text(label));
+
   /// We recommend to use [YaruPageItemTitle] here to have correct styling
   final WidgetBuilder titleBuilder;
+
+  final String label;
 
   final WidgetBuilder builder;
   final Widget Function(BuildContext context, bool selected) iconBuilder;

--- a/lib/src/pages/layouts/yaru_page_item_list_view.dart
+++ b/lib/src/pages/layouts/yaru_page_item_list_view.dart
@@ -36,20 +36,38 @@ class YaruPageItemListView extends StatelessWidget {
       controller: ScrollController(),
       itemCount: pages.length,
       itemBuilder: (context, index) => materialTiles
-          ? ListTile(
-              visualDensity: const VisualDensity(horizontal: -4, vertical: -4),
-              selected: index == selectedIndex,
-              title: pages[index].titleBuilder(context),
-              leading:
-                  pages[index].iconBuilder(context, index == selectedIndex),
-              onTap: () => onTap(index),
+          ? _buildSemanticContainer(
+              label: pages[index].label,
+              child: ListTile(
+                visualDensity:
+                    const VisualDensity(horizontal: -4, vertical: -4),
+                selected: index == selectedIndex,
+                title: pages[index].titleBuilder(context),
+                leading:
+                    pages[index].iconBuilder(context, index == selectedIndex),
+                onTap: () => onTap(index),
+              ),
             )
-          : _YaruListTile(
-              selected: index == selectedIndex,
-              title: pages[index].titleBuilder(context),
-              icon: pages[index].iconBuilder(context, index == selectedIndex),
-              onTap: () => onTap(index),
+          : _buildSemanticContainer(
+              label: pages[index].label,
+              child: _YaruListTile(
+                selected: index == selectedIndex,
+                title: pages[index].titleBuilder(context),
+                icon: pages[index].iconBuilder(context, index == selectedIndex),
+                onTap: () => onTap(index),
+              ),
             ),
+    );
+  }
+
+  Widget _buildSemanticContainer({
+    required String label,
+    required Widget child,
+  }) {
+    return Tooltip(
+      waitDuration: kWaitTooltipDuration,
+      message: label,
+      child: child,
     );
   }
 


### PR DESCRIPTION
![Capture d’écran du 2022-10-06 20-17-00](https://user-images.githubusercontent.com/36476595/194388822-89c97437-0de6-411d-b3a7-c718ef3787c0.png)
![Capture d’écran du 2022-10-06 20-17-16](https://user-images.githubusercontent.com/36476595/194388827-735f9e7b-a893-4ee5-94a4-49f42d68a09a.png)

This is useful when labels are elided (and it also add Semantics data);