### PR TITLE
YaruMasterDetailPage: add tile builder

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -65,8 +65,10 @@ class _HomeState extends State<Home> {
               leftPaneWidth: 280,
               previousIconData: YaruIcons.go_previous,
               length: pageItems.length,
-              iconBuilder: (context, index, selected) =>
-                  pageItems[index].iconBuilder(context, selected),
+              tileBuilder: (context, index, selected) => YaruMasterTile(
+                leading: pageItems[index].iconBuilder(context, selected),
+                title: pageItems[index].titleBuilder(context),
+              ),
               titleBuilder: (context, index, selected) =>
                   pageItems[index].titleBuilder(context),
               pageBuilder: (context, index) =>

--- a/lib/src/pages/layouts/yaru_landscape_layout.dart
+++ b/lib/src/pages/layouts/yaru_landscape_layout.dart
@@ -10,7 +10,7 @@ class YaruLandscapeLayout extends StatefulWidget {
     super.key,
     required this.length,
     required this.selectedIndex,
-    required this.iconBuilder,
+    required this.tileBuilder,
     required this.titleBuilder,
     required this.pageBuilder,
     required this.onSelected,
@@ -24,13 +24,13 @@ class YaruLandscapeLayout extends StatefulWidget {
   /// Current index of the selected page.
   final int selectedIndex;
 
-  /// A builder that is called for each page to build its icon.
-  final YaruMasterDetailBuilder iconBuilder;
+  /// A builder that is called for each page to build its master tile.
+  final YaruMasterDetailBuilder tileBuilder;
 
   /// A builder that is called for each page to build its title.
   final YaruMasterDetailBuilder titleBuilder;
 
-  /// A builder that is called for each page to build its content.
+  /// A builder that is called for each page to build its detail page.
   final IndexedWidgetBuilder pageBuilder;
 
   /// Callback that returns an index when the page changes.
@@ -109,8 +109,7 @@ class _YaruLandscapeLayoutState extends State<YaruLandscapeLayout> {
                       length: widget.length,
                       selectedIndex: _selectedIndex,
                       onTap: _onTap,
-                      iconBuilder: widget.iconBuilder,
-                      titleBuilder: widget.titleBuilder,
+                      builder: widget.tileBuilder,
                     ),
                   ),
                 ),

--- a/lib/src/pages/layouts/yaru_master_detail_page.dart
+++ b/lib/src/pages/layouts/yaru_master_detail_page.dart
@@ -27,7 +27,7 @@ class YaruMasterDetailPage extends StatefulWidget {
   const YaruMasterDetailPage({
     super.key,
     required this.length,
-    required this.iconBuilder,
+    required this.tileBuilder,
     required this.titleBuilder,
     required this.pageBuilder,
     this.previousIconData,
@@ -40,13 +40,13 @@ class YaruMasterDetailPage extends StatefulWidget {
   /// The total number of pages.
   final int length;
 
-  /// A builder that is called for each page to build its icon.
-  final YaruMasterDetailBuilder iconBuilder;
+  /// A builder that is called for each page to build its master tile.
+  final YaruMasterDetailBuilder tileBuilder;
 
   /// A builder that is called for each page to build its title.
   final YaruMasterDetailBuilder titleBuilder;
 
-  /// A builder that is called for each page to build its content.
+  /// A builder that is called for each page to build its detail page.
   final IndexedWidgetBuilder pageBuilder;
 
   /// Specifies the width of left pane.
@@ -100,7 +100,7 @@ class _YaruMasterDetailPageState extends State<YaruMasterDetailPage> {
           return YaruPortraitLayout(
             length: widget.length,
             selectedIndex: _index,
-            iconBuilder: widget.iconBuilder,
+            tileBuilder: widget.tileBuilder,
             titleBuilder: widget.titleBuilder,
             pageBuilder: widget.pageBuilder,
             onSelected: _setIndex,
@@ -111,7 +111,7 @@ class _YaruMasterDetailPageState extends State<YaruMasterDetailPage> {
           return YaruLandscapeLayout(
             length: widget.length,
             selectedIndex: _index == -1 ? _previousIndex : _index,
-            iconBuilder: widget.iconBuilder,
+            tileBuilder: widget.tileBuilder,
             titleBuilder: widget.titleBuilder,
             pageBuilder: widget.pageBuilder,
             onSelected: _setIndex,

--- a/lib/src/pages/layouts/yaru_master_tile.dart
+++ b/lib/src/pages/layouts/yaru_master_tile.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+
+import '../../constants.dart';
+import 'yaru_page_item_title.dart';
+
+class YaruMasterTile extends StatelessWidget {
+  const YaruMasterTile({
+    super.key,
+    this.selected,
+    this.leading,
+    required this.title,
+    this.subtitle,
+    this.trailing,
+    this.onTap,
+  });
+
+  final bool? selected;
+  final Widget? leading;
+  final Widget? title;
+  final Widget? subtitle;
+  final Widget? trailing;
+  final Function()? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final scope = YaruMasterTileScope.maybeOf(context);
+    final isSelected = selected ?? scope?.selected ?? false;
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        borderRadius:
+            const BorderRadius.all(Radius.circular(kYaruButtonRadius)),
+        color: isSelected
+            ? Theme.of(context).colorScheme.onSurface.withOpacity(0.07)
+            : null,
+      ),
+      child: ListTile(
+        textColor: Theme.of(context).colorScheme.onSurface,
+        selectedColor: Theme.of(context).colorScheme.onSurface,
+        iconColor: Theme.of(context).colorScheme.onSurface.withOpacity(0.8),
+        visualDensity: const VisualDensity(horizontal: -4, vertical: -4),
+        shape: const RoundedRectangleBorder(
+          borderRadius: BorderRadius.all(Radius.circular(kYaruButtonRadius)),
+        ),
+        leading: leading,
+        title: _buildTitle(),
+        subtitle: subtitle,
+        trailing: trailing,
+        selected: isSelected,
+        onTap: () {
+          final scope = YaruMasterTileScope.maybeOf(context);
+          scope?.onTap();
+          onTap?.call();
+        },
+      ),
+    );
+  }
+
+  Widget? _buildTitle() {
+    if (title == null) {
+      return title;
+    }
+
+    if (title is YaruPageItemTitle) {
+      return DefaultTextStyle.merge(
+        child: title!,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      );
+    }
+
+    return title;
+  }
+}
+
+class YaruMasterTileScope extends InheritedWidget {
+  const YaruMasterTileScope({
+    super.key,
+    required super.child,
+    required this.index,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final int index;
+  final bool selected;
+  final VoidCallback onTap;
+
+  static YaruMasterTileScope of(BuildContext context) {
+    return maybeOf(context)!;
+  }
+
+  static YaruMasterTileScope? maybeOf(BuildContext context) {
+    return context.dependOnInheritedWidgetOfExactType<YaruMasterTileScope>();
+  }
+
+  @override
+  bool updateShouldNotify(YaruMasterTileScope oldWidget) {
+    return selected != oldWidget.selected || index != oldWidget.index;
+  }
+}

--- a/lib/src/pages/layouts/yaru_page_item_list_view.dart
+++ b/lib/src/pages/layouts/yaru_page_item_list_view.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
-import '../../../yaru_widgets.dart';
+import 'yaru_master_detail_page.dart';
+import 'yaru_master_tile.dart';
 
 const double _kScrollbarThickness = 8.0;
 const double _kScrollbarMargin = 2.0;
@@ -10,15 +11,13 @@ class YaruPageItemListView extends StatelessWidget {
     super.key,
     required this.length,
     required this.selectedIndex,
-    required this.iconBuilder,
-    required this.titleBuilder,
+    required this.builder,
     required this.onTap,
     this.materialTiles = false,
   });
 
   final int length;
-  final YaruMasterDetailBuilder iconBuilder;
-  final YaruMasterDetailBuilder titleBuilder;
+  final YaruMasterDetailBuilder builder;
   final int selectedIndex;
   final Function(int index) onTap;
   final bool materialTiles;
@@ -38,20 +37,14 @@ class YaruPageItemListView extends StatelessWidget {
           : null,
       controller: ScrollController(),
       itemCount: length,
-      itemBuilder: (context, index) => materialTiles
-          ? ListTile(
-              visualDensity: const VisualDensity(horizontal: -4, vertical: -4),
-              selected: index == selectedIndex,
-              title: titleBuilder(context, index, index == selectedIndex),
-              leading: iconBuilder(context, index, index == selectedIndex),
-              onTap: () => onTap(index),
-            )
-          : _YaruListTile(
-              selected: index == selectedIndex,
-              title: titleBuilder(context, index, index == selectedIndex),
-              icon: iconBuilder(context, index, index == selectedIndex),
-              onTap: () => onTap(index),
-            ),
+      itemBuilder: (context, index) => YaruMasterTileScope(
+        index: index,
+        selected: index == selectedIndex,
+        onTap: () => onTap(index),
+        child: Builder(
+          builder: (context) => builder(context, index, index == selectedIndex),
+        ),
+      ),
     );
   }
 
@@ -67,61 +60,5 @@ class YaruPageItemListView extends StatelessWidget {
             _kScrollbarThickness;
 
     return doubleMarginWidth + scrollBarThumbThikness;
-  }
-}
-
-class _YaruListTile extends StatelessWidget {
-  const _YaruListTile({
-    required this.selected,
-    this.icon,
-    required this.onTap,
-    required this.title,
-  });
-
-  final bool selected;
-  final Widget? icon;
-  final Function() onTap;
-  final Widget? title;
-
-  @override
-  Widget build(BuildContext context) {
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        borderRadius:
-            const BorderRadius.all(Radius.circular(kYaruButtonRadius)),
-        color: selected
-            ? Theme.of(context).colorScheme.onSurface.withOpacity(0.07)
-            : null,
-      ),
-      child: ListTile(
-        textColor: Theme.of(context).colorScheme.onSurface,
-        selectedColor: Theme.of(context).colorScheme.onSurface,
-        iconColor: Theme.of(context).colorScheme.onSurface.withOpacity(0.8),
-        visualDensity: const VisualDensity(horizontal: -4, vertical: -4),
-        shape: const RoundedRectangleBorder(
-          borderRadius: BorderRadius.all(Radius.circular(kYaruButtonRadius)),
-        ),
-        leading: icon,
-        title: _buildTitle(),
-        selected: selected,
-        onTap: onTap,
-      ),
-    );
-  }
-
-  Widget? _buildTitle() {
-    if (title == null) {
-      return title;
-    }
-
-    if (title is YaruPageItemTitle) {
-      return DefaultTextStyle.merge(
-        child: title!,
-        maxLines: 1,
-        overflow: TextOverflow.ellipsis,
-      );
-    }
-
-    return title;
   }
 }

--- a/lib/src/pages/layouts/yaru_portrait_layout.dart
+++ b/lib/src/pages/layouts/yaru_portrait_layout.dart
@@ -9,7 +9,7 @@ class YaruPortraitLayout extends StatefulWidget {
     super.key,
     required this.length,
     required this.selectedIndex,
-    required this.iconBuilder,
+    required this.tileBuilder,
     required this.titleBuilder,
     required this.pageBuilder,
     required this.onSelected,
@@ -19,7 +19,7 @@ class YaruPortraitLayout extends StatefulWidget {
 
   final int length;
   final int selectedIndex;
-  final YaruMasterDetailBuilder iconBuilder;
+  final YaruMasterDetailBuilder tileBuilder;
   final YaruMasterDetailBuilder titleBuilder;
   final IndexedWidgetBuilder pageBuilder;
   final ValueChanged<int> onSelected;
@@ -105,8 +105,7 @@ class _YaruPortraitLayoutState extends State<YaruPortraitLayout> {
                       length: widget.length,
                       selectedIndex: _selectedIndex,
                       onTap: _onTap,
-                      iconBuilder: widget.iconBuilder,
-                      titleBuilder: widget.titleBuilder,
+                      builder: widget.tileBuilder,
                     ),
                   );
                 },

--- a/lib/yaru_widgets.dart
+++ b/lib/yaru_widgets.dart
@@ -17,6 +17,7 @@ export 'src/extensions/border_radius_extension.dart';
 // Pages layouts
 export 'src/pages/layouts/yaru_compact_layout.dart';
 export 'src/pages/layouts/yaru_master_detail_page.dart';
+export 'src/pages/layouts/yaru_master_tile.dart';
 export 'src/pages/layouts/yaru_navigation_rail.dart';
 export 'src/pages/layouts/yaru_page_item_title.dart';
 // Pages


### PR DESCRIPTION
This gives full control over master-detail tiles. Notice that `YaruMasterTile` can be wrapped with any other widget such as `Tooltip` or `Semantics`.

### Before
```dart
YaruMasterDetailPage(
  iconBuilder: (context, index, selected) => const Icon(Icons.foo),
  titleBuilder: (context, index, selected) => const Text('Title'),
)
```

### After
```dart
YaruMasterDetailPage(
  tileBuilder: (context, index, selected) => YaruMasterTile(
    leading: const Icon(Icons.foo),
    title: const Text('Custom'),
    subtitle: const Text('Lorem ipsum...'),
    trailing: const Chip(label: Text('123'),
    onTap: () {},
  ),
)
```

![image](https://user-images.githubusercontent.com/140617/194626920-6c99d99a-eabe-4261-9a88-b7b406c816fd.png)

Ref: #255