### PR TITLE
YaruPortraitLayout: remove the FAB

### DIFF
--- a/lib/src/pages/layouts/yaru_portrait_layout.dart
+++ b/lib/src/pages/layouts/yaru_portrait_layout.dart
@@ -71,15 +71,6 @@ class _YaruPortraitLayoutState extends State<YaruPortraitLayout> {
               : null,
           body:
               SizedBox(width: width, child: widget.pageBuilder(context, index)),
-          floatingActionButton: widget.appBar == null
-              ? FloatingActionButton(
-                  child: Icon(widget.previousIconData),
-                  onPressed: _goBack,
-                )
-              : null,
-          floatingActionButtonLocation: widget.appBar == null
-              ? FloatingActionButtonLocation.miniStartFloat
-              : null,
         );
       },
     );


### PR DESCRIPTION
Let apps decide where they want to put the back button if they are not using an app bar.

![image](https://user-images.githubusercontent.com/140617/194750231-cbe9dcfe-7104-43a0-a8b6-23a304977a94.png)