### PR TITLE
Example: center the toggle button to avoid stretching it

### DIFF
--- a/example/lib/pages/round_toggle_button_page.dart
+++ b/example/lib/pages/round_toggle_button_page.dart
@@ -16,13 +16,15 @@ class _RoundToggleButtonPageState extends State<RoundToggleButtonPage> {
     return ListView(
       padding: const EdgeInsets.all(kYaruPagePadding),
       children: [
-        YaruRoundToggleButton(
-          onPressed: () => setState(
-            () => _selected = !_selected,
+        Center(
+          child: YaruRoundToggleButton(
+            onPressed: () => setState(
+              () => _selected = !_selected,
+            ),
+            selected: _selected,
+            iconData: YaruIcons.view,
+            tooltip: 'View',
           ),
-          selected: _selected,
-          iconData: YaruIcons.view,
-          tooltip: 'View',
         )
       ],
     );


### PR DESCRIPTION
| Before | After |
|---|---|
| ![Screenshot from 2022-10-09 17-55-01](https://user-images.githubusercontent.com/140617/194766846-f105c2e6-6121-4167-b875-4e27ff0adfea.png) | ![Screenshot from 2022-10-09 17-54-55](https://user-images.githubusercontent.com/140617/194766853-0c8194ee-84ad-419c-aeaa-b2bf356857c8.png) |

Fixes: #257