### PR TITLE
Add YaruBackButton

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -63,7 +63,6 @@ class _HomeState extends State<Home> {
           ? _CompactPage(configItem: configItem)
           : YaruMasterDetailPage(
               leftPaneWidth: 280,
-              previousIconData: YaruIcons.go_previous,
               length: pageItems.length,
               tileBuilder: (context, index, selected) => YaruMasterTile(
                 leading: pageItems[index].iconBuilder(context, selected),

--- a/lib/src/controls/yaru_back_button.dart
+++ b/lib/src/controls/yaru_back_button.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:yaru_icons/yaru_icons.dart';
+
+import 'yaru_icon_button.dart';
+
+/// A Yaru style back button.
+class YaruBackButton extends StatelessWidget {
+  /// Creates a [YaruIconButton].
+  const YaruBackButton({super.key, this.onPressed});
+
+  /// An optional callback that is called when the button is pressed.
+  ///
+  /// By default, [Navigator.maybePop] is called.
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: YaruIconButton(
+        icon: const Icon(YaruIcons.go_previous),
+        onPressed: () {
+          if (onPressed != null) {
+            onPressed!();
+          } else {
+            Navigator.maybePop(context);
+          }
+        },
+      ),
+    );
+  }
+}

--- a/lib/src/controls/yaru_back_button.dart
+++ b/lib/src/controls/yaru_back_button.dart
@@ -15,17 +15,18 @@ class YaruBackButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Center(
-      child: YaruIconButton(
-        icon: const Icon(YaruIcons.go_previous),
-        onPressed: () {
-          if (onPressed != null) {
-            onPressed!();
-          } else {
-            Navigator.maybePop(context);
-          }
-        },
+    return YaruIconButton(
+      icon: const Icon(YaruIcons.go_previous),
+      style: ButtonStyle(
+        shape: ButtonStyleButton.allOrNull(const BeveledRectangleBorder()),
       ),
+      onPressed: () {
+        if (onPressed != null) {
+          onPressed!();
+        } else {
+          Navigator.maybePop(context);
+        }
+      },
     );
   }
 }

--- a/lib/src/controls/yaru_back_button.dart
+++ b/lib/src/controls/yaru_back_button.dart
@@ -5,7 +5,7 @@ import 'yaru_icon_button.dart';
 
 /// A Yaru style back button.
 class YaruBackButton extends StatelessWidget {
-  /// Creates a [YaruIconButton].
+  /// Creates a [YaruBackButton].
   const YaruBackButton({super.key, this.onPressed});
 
   /// An optional callback that is called when the button is pressed.

--- a/lib/src/pages/layouts/yaru_master_detail_page.dart
+++ b/lib/src/pages/layouts/yaru_master_detail_page.dart
@@ -30,7 +30,6 @@ class YaruMasterDetailPage extends StatefulWidget {
     required this.tileBuilder,
     required this.titleBuilder,
     required this.pageBuilder,
-    this.previousIconData,
     required this.leftPaneWidth,
     this.appBar,
     this.initialIndex,
@@ -51,9 +50,6 @@ class YaruMasterDetailPage extends StatefulWidget {
 
   /// Specifies the width of left pane.
   final double leftPaneWidth;
-
-  /// Property to specify the previous icon data
-  final IconData? previousIconData;
 
   /// An optional custom AppBar for the left pane.
   final PreferredSizeWidget? appBar;
@@ -104,7 +100,6 @@ class _YaruMasterDetailPageState extends State<YaruMasterDetailPage> {
             titleBuilder: widget.titleBuilder,
             pageBuilder: widget.pageBuilder,
             onSelected: _setIndex,
-            previousIconData: widget.previousIconData,
             appBar: widget.appBar,
           );
         } else {

--- a/lib/src/pages/layouts/yaru_portrait_layout.dart
+++ b/lib/src/pages/layouts/yaru_portrait_layout.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:yaru/yaru.dart';
 
+import '../../controls/yaru_back_button.dart';
 import 'yaru_master_detail_page.dart';
 import 'yaru_page_item_list_view.dart';
 
@@ -61,10 +62,8 @@ class _YaruPortraitLayoutState extends State<YaruPortraitLayout> {
           appBar: widget.appBar != null
               ? AppBar(
                   title: widget.titleBuilder(context, index, false),
-                  leading: InkWell(
-                    child:
-                        Icon(widget.previousIconData ?? Icons.navigate_before),
-                    onTap: _goBack,
+                  leading: YaruBackButton(
+                    onPressed: _goBack,
                   ),
                 )
               : null,

--- a/lib/src/pages/layouts/yaru_portrait_layout.dart
+++ b/lib/src/pages/layouts/yaru_portrait_layout.dart
@@ -14,7 +14,6 @@ class YaruPortraitLayout extends StatefulWidget {
     required this.titleBuilder,
     required this.pageBuilder,
     required this.onSelected,
-    this.previousIconData,
     this.appBar,
   });
 
@@ -24,7 +23,6 @@ class YaruPortraitLayout extends StatefulWidget {
   final YaruMasterDetailBuilder titleBuilder;
   final IndexedWidgetBuilder pageBuilder;
   final ValueChanged<int> onSelected;
-  final IconData? previousIconData;
 
   final PreferredSizeWidget? appBar;
 

--- a/lib/yaru_widgets.dart
+++ b/lib/yaru_widgets.dart
@@ -3,6 +3,7 @@ library yaru_widgets;
 // Constants
 export 'src/constants.dart';
 // Controls
+export 'src/controls/yaru_back_button.dart';
 export 'src/controls/yaru_color_disk.dart';
 export 'src/controls/yaru_icon_button.dart';
 export 'src/controls/yaru_option_button.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
   yaru: ^0.4.1
+  yaru_icons: ^0.2.4
 
 dev_dependencies:
   flutter_lints: ^1.0.0


### PR DESCRIPTION
This is a pre-requisite for the master-detail app bar removal (#255), also discussed in ubuntu-flutter-community/software#354.

P.S. Proposing `YaruBackButton` instead of `YaruIconButton.back` because the former is easier to discover :slightly_smiling_face:

**NOTE**: rectangular vs. circular shape change and a dependency to **yaru_icons** - are these acceptable?

| Before | ~~After~~ | After
|---|---|---|
| ![Screenshot from 2022-10-10 11-45-08](https://user-images.githubusercontent.com/140617/194839092-fa9a1dc9-338f-494b-9ac4-24673e368104.png) | ![Screenshot from 2022-10-10 11-44-55](https://user-images.githubusercontent.com/140617/194839102-a66079e0-c98d-4aef-86ba-9794c76909f4.png) | ![Screenshot from 2022-10-10 11-45-08](https://user-images.githubusercontent.com/140617/194844697-7fc4ab4d-4d0d-48ec-a5fa-b38794e302a0.png) |