### PR TITLE
Use widgets as parameters in Yaru[Section,TabbedPage,Banner]

### DIFF
--- a/example/lib/pages/banner_page.dart
+++ b/example/lib/pages/banner_page.dart
@@ -18,8 +18,8 @@ class BannerPage extends StatelessWidget {
       children: [
         for (int i = 0; i < 20; i++)
           YaruBanner(
-            name: 'YaruBanner $i',
-            summary: 'Description',
+            name: Text('YaruBanner $i'),
+            subtitleWidget: const Text('Description'),
             icon: Image.asset('assets/ubuntuhero.jpg'),
             onTap: () => showAboutDialog(context: context),
           )

--- a/example/lib/pages/carousel_page.dart
+++ b/example/lib/pages/carousel_page.dart
@@ -18,7 +18,7 @@ class _CarouselPageState extends State<CarouselPage> {
       padding: const EdgeInsets.all(kYaruPagePadding),
       children: [
         YaruSection(
-          headline: 'Auto scroll: off',
+          headline: const Text('Auto scroll: off'),
           width: 700,
           children: [
             YaruCarousel(
@@ -34,7 +34,7 @@ class _CarouselPageState extends State<CarouselPage> {
           ],
         ),
         YaruSection(
-          headline: 'Auto scroll: on',
+          headline: const Text('Auto scroll: on'),
           width: 700,
           children: [
             YaruCarousel(

--- a/example/lib/pages/section_page.dart
+++ b/example/lib/pages/section_page.dart
@@ -42,7 +42,7 @@ class DummySection extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return YaruSection(
-      headline: 'Headline',
+      headline: const Text('Headline'),
       headerWidget: const SizedBox(
         child: YaruCircularProgressIndicator(strokeWidth: 3),
         height: 20,

--- a/example/lib/pages/tabbed_page_page.dart
+++ b/example/lib/pages/tabbed_page_page.dart
@@ -31,8 +31,8 @@ class _TabbedPagePageState extends State<TabbedPagePage> {
           children: [
             for (int i = 0; i < 20; i++)
               YaruBanner(
-                name: 'YaruBanner $i',
-                summary: 'Description',
+                name: Text('YaruBanner $i'),
+                subtitleWidget: const Text('Description'),
                 icon: Image.asset('assets/ubuntuhero.jpg'),
                 onTap: () => showAboutDialog(context: context),
               )
@@ -49,7 +49,7 @@ class _TabbedPagePageState extends State<TabbedPagePage> {
         YaruIcons.audio,
         YaruIcons.address_book,
         YaruIcons.television
-      ],
+      ].map(Icon.new).toList(),
       tabTitles: const [
         'Addons',
         'Accessibility',

--- a/lib/src/pages/yaru_section.dart
+++ b/lib/src/pages/yaru_section.dart
@@ -13,8 +13,8 @@ class YaruSection extends StatelessWidget {
     this.padding = const EdgeInsets.only(bottom: 20.0),
   });
 
-  /// Text that is placed above the list of `children`.
-  final String? headline;
+  /// Widget that is placed above the list of `children`.
+  final Widget? headline;
 
   ///  Creates a vertical list of widgets.
   ///  All children will be of type [Widget],
@@ -59,10 +59,10 @@ class YaruSection extends StatelessWidget {
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
                     children: [
                       if (headline != null)
-                        Text(
-                          headline!,
-                          style: Theme.of(context).textTheme.titleLarge,
+                        DefaultTextStyle(
+                          style: Theme.of(context).textTheme.titleLarge!,
                           textAlign: TextAlign.left,
+                          child: headline!,
                         ),
                       headerWidget ?? const SizedBox()
                     ],

--- a/lib/src/pages/yaru_tabbed_page.dart
+++ b/lib/src/pages/yaru_tabbed_page.dart
@@ -21,8 +21,8 @@ class YaruTabbedPage extends StatefulWidget {
     this.onTap,
   });
 
-  /// A list of [IconData] used inside the tabs - must have the same length as [tabTitles] and [views].
-  final List<IconData> tabIcons;
+  /// A list of [Icon]s used inside the tabs - must have the same length as [tabTitles] and [views].
+  final List<Icon> tabIcons;
 
   /// The list of titles as [String]s - must have the same length as [tabIcons] and [views].
   final List<String> tabTitles;
@@ -108,9 +108,7 @@ class _YaruTabbedPageState extends State<YaruTabbedPage>
                   for (var i = 0; i < widget.views.length; i++)
                     Tab(
                       text: titlesDoNotFit() ? null : widget.tabTitles[i],
-                      icon: Icon(
-                        widget.tabIcons[i],
-                      ),
+                      icon: widget.tabIcons[i],
                     )
                 ],
               ),

--- a/lib/src/utilities/yaru_banner.dart
+++ b/lib/src/utilities/yaru_banner.dart
@@ -9,7 +9,6 @@ class YaruBanner extends StatelessWidget {
     this.surfaceTintColor,
     this.watermark = false,
     required this.name,
-    this.summary,
     required this.icon,
     this.nameTextOverflow,
     this.summaryTextOverflow,
@@ -18,12 +17,10 @@ class YaruBanner extends StatelessWidget {
   });
 
   /// The name of the card
-  final String name;
+  final Widget name;
 
+  /// The subtitle shown in the second line.
   final Widget? subtitleWidget;
-
-  /// A summary string shown in the second line.
-  final String? summary;
 
   /// An optional callback
   final Function()? onTap;
@@ -66,7 +63,6 @@ class YaruBanner extends StatelessWidget {
                     borderRadius: borderRadius,
                     color: surfaceTintColor!,
                     title: name,
-                    summary: summary,
                     elevation: light ? 4 : 6,
                     icon: icon,
                     titleTextOverflow:
@@ -102,7 +98,6 @@ class YaruBanner extends StatelessWidget {
                 elevation: light ? 2 : 1,
                 icon: icon,
                 title: name,
-                summary: summary,
                 titleTextOverflow: nameTextOverflow ?? TextOverflow.ellipsis,
                 subTitleTextOverflow:
                     summaryTextOverflow ?? TextOverflow.ellipsis,
@@ -117,7 +112,6 @@ class _Banner extends StatelessWidget {
   const _Banner({
     required this.color,
     required this.title,
-    this.summary,
     required this.elevation,
     required this.icon,
     required this.borderRadius,
@@ -129,8 +123,7 @@ class _Banner extends StatelessWidget {
   });
 
   final Color color;
-  final String title;
-  final String? summary;
+  final Widget title;
   final double elevation;
   final Widget icon;
   final BorderRadius borderRadius;
@@ -157,12 +150,17 @@ class _Banner extends StatelessWidget {
           width: width ?? 370,
           child: ListTile(
             mouseCursor: mouseCursor,
-            subtitle: subtitleWidget ??
-                (summary != null
-                    ? Text(summary!, overflow: subTitleTextOverflow)
-                    : null),
-            title: Text(
-              title,
+            subtitle: subtitleWidget != null
+                ? DefaultTextStyle(
+                    style: Theme.of(context).textTheme.bodyMedium!.copyWith(
+                          color: Theme.of(context).textTheme.bodySmall!.color,
+                          overflow: subTitleTextOverflow,
+                        ),
+                    child: subtitleWidget!,
+                  )
+                : null,
+            title: DefaultTextStyle(
+              child: title,
               style: TextStyle(fontSize: 20, overflow: titleTextOverflow),
             ),
             leading: SizedBox(


### PR DESCRIPTION
I've replaced `String` and `IconData` parameters with `Widget` and `Icon`, respectively.
The `summary` parameter in `YaruBanner` was redundant, so I removed it.