### PR TITLE
Yaru master detail theme

### DIFF
--- a/lib/src/pages/layouts/yaru_landscape_layout.dart
+++ b/lib/src/pages/layouts/yaru_landscape_layout.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:yaru/yaru.dart';
 
 import 'yaru_master_detail_page.dart';
+import 'yaru_master_detail_theme.dart';
 import 'yaru_page_item_list_view.dart';
 
 class YaruLandscapeLayout extends StatefulWidget {
@@ -63,6 +63,7 @@ class _YaruLandscapeLayoutState extends State<YaruLandscapeLayout> {
 
   @override
   Widget build(BuildContext context) {
+    final theme = YaruMasterDetailTheme.of(context);
     return Row(
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -90,7 +91,7 @@ class _YaruLandscapeLayoutState extends State<YaruLandscapeLayout> {
         Expanded(
           child: Theme(
             data: Theme.of(context).copyWith(
-              pageTransitionsTheme: YaruPageTransitionsTheme.vertical,
+              pageTransitionsTheme: theme.landscapeTransitions,
             ),
             child: Navigator(
               pages: [

--- a/lib/src/pages/layouts/yaru_master_detail_page.dart
+++ b/lib/src/pages/layouts/yaru_master_detail_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'yaru_landscape_layout.dart';
+import 'yaru_master_detail_theme.dart';
 import 'yaru_portrait_layout.dart';
 
 typedef YaruMasterDetailBuilder = Widget Function(
@@ -96,9 +97,11 @@ class _YaruMasterDetailPageState extends State<YaruMasterDetailPage> {
 
   @override
   Widget build(BuildContext context) {
+    final breakpoint = YaruMasterDetailTheme.of(context).breakpoint ??
+        YaruMasterDetailThemeData.fallback().breakpoint!;
     return LayoutBuilder(
       builder: (context, constraints) {
-        if (constraints.maxWidth < 620) {
+        if (constraints.maxWidth < breakpoint) {
           return YaruPortraitLayout(
             length: widget.length,
             selectedIndex: _index,

--- a/lib/src/pages/layouts/yaru_master_detail_theme.dart
+++ b/lib/src/pages/layouts/yaru_master_detail_theme.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:yaru/yaru.dart';
+
+@immutable
+class YaruMasterDetailThemeData with Diagnosticable {
+  /// Creates a theme that can be used with [YaruMasterDetailPage].
+  const YaruMasterDetailThemeData({
+    this.breakpoint,
+    this.tileSpacing,
+    this.listPadding,
+    this.portraitTransitions,
+    this.landscapeTransitions,
+  });
+
+  factory YaruMasterDetailThemeData.fallback() {
+    return const YaruMasterDetailThemeData(
+      breakpoint: 620,
+      tileSpacing: 6,
+      listPadding: EdgeInsets.symmetric(vertical: 8),
+      portraitTransitions: YaruPageTransitionsTheme.horizontal,
+      landscapeTransitions: YaruPageTransitionsTheme.vertical,
+    );
+  }
+
+  /// The breakpoint at which `YaruMasterDetailPage` switches between portrait
+  /// and landscape layouts.
+  final double? breakpoint;
+
+  /// The spacing between tiles in the master list.
+  final double? tileSpacing;
+
+  /// The padding around the master list.
+  final EdgeInsets? listPadding;
+
+  /// The page transitions to use when in portrait mode.
+  final PageTransitionsTheme? portraitTransitions;
+
+  /// The page transitions to use when in landscape mode.
+  final PageTransitionsTheme? landscapeTransitions;
+
+  /// Creates a copy of this object but with the given fields replaced with the
+  /// new values.
+  YaruMasterDetailThemeData copyWith({
+    double? breakpoint,
+    double? tileSpacing,
+    EdgeInsets? listPadding,
+    PageTransitionsTheme? portraitTransitions,
+    PageTransitionsTheme? landscapeTransitions,
+  }) {
+    return YaruMasterDetailThemeData(
+      breakpoint: breakpoint ?? this.breakpoint,
+      tileSpacing: tileSpacing ?? this.tileSpacing,
+      listPadding: listPadding ?? this.listPadding,
+      portraitTransitions: portraitTransitions ?? this.portraitTransitions,
+      landscapeTransitions: landscapeTransitions ?? this.landscapeTransitions,
+    );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DoubleProperty('breakpoint', breakpoint));
+    properties.add(DoubleProperty('tileSpacing', tileSpacing));
+    properties.add(DiagnosticsProperty('listPadding', listPadding));
+    properties
+        .add(DiagnosticsProperty('portraitTransitions', portraitTransitions));
+    properties
+        .add(DiagnosticsProperty('landscapeTransitions', landscapeTransitions));
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is YaruMasterDetailThemeData &&
+        other.breakpoint == breakpoint &&
+        other.tileSpacing == tileSpacing &&
+        other.listPadding == listPadding &&
+        other.portraitTransitions == portraitTransitions &&
+        other.landscapeTransitions == landscapeTransitions;
+  }
+
+  @override
+  int get hashCode {
+    return Object.hash(
+      breakpoint,
+      tileSpacing,
+      listPadding,
+      portraitTransitions,
+      landscapeTransitions,
+    );
+  }
+}
+
+class YaruMasterDetailTheme extends InheritedTheme {
+  const YaruMasterDetailTheme({
+    super.key,
+    required this.data,
+    required super.child,
+  });
+
+  final YaruMasterDetailThemeData data;
+
+  static YaruMasterDetailThemeData of(BuildContext context) {
+    final theme =
+        context.dependOnInheritedWidgetOfExactType<YaruMasterDetailTheme>();
+    return theme?.data ?? YaruMasterDetailThemeData.fallback();
+  }
+
+  @override
+  Widget wrap(BuildContext context, Widget child) {
+    return YaruMasterDetailTheme(data: data, child: child);
+  }
+
+  @override
+  bool updateShouldNotify(YaruMasterDetailTheme oldWidget) {
+    return data != oldWidget.data;
+  }
+}

--- a/lib/src/pages/layouts/yaru_master_tile.dart
+++ b/lib/src/pages/layouts/yaru_master_tile.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 
 import '../../constants.dart';
-import 'yaru_page_item_title.dart';
 
 const double _kScrollbarThickness = 8.0;
 const double _kScrollbarMargin = 2.0;
@@ -50,8 +49,8 @@ class YaruMasterTile extends StatelessWidget {
             borderRadius: BorderRadius.all(Radius.circular(kYaruButtonRadius)),
           ),
           leading: leading,
-          title: _buildTitle(),
-          subtitle: subtitle,
+          title: _buildChild(title),
+          subtitle: _buildChild(subtitle),
           trailing: trailing,
           selected: isSelected,
           onTap: () {
@@ -64,20 +63,16 @@ class YaruMasterTile extends StatelessWidget {
     );
   }
 
-  Widget? _buildTitle() {
-    if (title == null) {
-      return title;
+  Widget? _buildChild(Widget? child) {
+    if (child == null) {
+      return child;
     }
 
-    if (title is YaruPageItemTitle) {
-      return DefaultTextStyle.merge(
-        child: title!,
-        maxLines: 1,
-        overflow: TextOverflow.ellipsis,
-      );
-    }
-
-    return title;
+    return DefaultTextStyle.merge(
+      child: child,
+      maxLines: 1,
+      overflow: TextOverflow.ellipsis,
+    );
   }
 
   double _calcScrollbarThicknessWithTrack(final BuildContext context) {

--- a/lib/src/pages/layouts/yaru_master_tile.dart
+++ b/lib/src/pages/layouts/yaru_master_tile.dart
@@ -3,6 +3,9 @@ import 'package:flutter/material.dart';
 import '../../constants.dart';
 import 'yaru_page_item_title.dart';
 
+const double _kScrollbarThickness = 8.0;
+const double _kScrollbarMargin = 2.0;
+
 class YaruMasterTile extends StatelessWidget {
   const YaruMasterTile({
     super.key,
@@ -25,33 +28,38 @@ class YaruMasterTile extends StatelessWidget {
   Widget build(BuildContext context) {
     final scope = YaruMasterTileScope.maybeOf(context);
     final isSelected = selected ?? scope?.selected ?? false;
+    final scrollbarThicknessWithTrack =
+        _calcScrollbarThicknessWithTrack(context);
 
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        borderRadius:
-            const BorderRadius.all(Radius.circular(kYaruButtonRadius)),
-        color: isSelected
-            ? Theme.of(context).colorScheme.onSurface.withOpacity(0.07)
-            : null,
-      ),
-      child: ListTile(
-        textColor: Theme.of(context).colorScheme.onSurface,
-        selectedColor: Theme.of(context).colorScheme.onSurface,
-        iconColor: Theme.of(context).colorScheme.onSurface.withOpacity(0.8),
-        visualDensity: const VisualDensity(horizontal: -4, vertical: -4),
-        shape: const RoundedRectangleBorder(
-          borderRadius: BorderRadius.all(Radius.circular(kYaruButtonRadius)),
+    return Padding(
+      padding: EdgeInsets.symmetric(horizontal: scrollbarThicknessWithTrack),
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          borderRadius:
+              const BorderRadius.all(Radius.circular(kYaruButtonRadius)),
+          color: isSelected
+              ? Theme.of(context).colorScheme.onSurface.withOpacity(0.07)
+              : null,
         ),
-        leading: leading,
-        title: _buildTitle(),
-        subtitle: subtitle,
-        trailing: trailing,
-        selected: isSelected,
-        onTap: () {
-          final scope = YaruMasterTileScope.maybeOf(context);
-          scope?.onTap();
-          onTap?.call();
-        },
+        child: ListTile(
+          textColor: Theme.of(context).colorScheme.onSurface,
+          selectedColor: Theme.of(context).colorScheme.onSurface,
+          iconColor: Theme.of(context).colorScheme.onSurface.withOpacity(0.8),
+          visualDensity: const VisualDensity(horizontal: -4, vertical: -4),
+          shape: const RoundedRectangleBorder(
+            borderRadius: BorderRadius.all(Radius.circular(kYaruButtonRadius)),
+          ),
+          leading: leading,
+          title: _buildTitle(),
+          subtitle: subtitle,
+          trailing: trailing,
+          selected: isSelected,
+          onTap: () {
+            final scope = YaruMasterTileScope.maybeOf(context);
+            scope?.onTap();
+            onTap?.call();
+          },
+        ),
       ),
     );
   }
@@ -70,6 +78,20 @@ class YaruMasterTile extends StatelessWidget {
     }
 
     return title;
+  }
+
+  double _calcScrollbarThicknessWithTrack(final BuildContext context) {
+    final scrollbarTheme = Theme.of(context).scrollbarTheme;
+
+    final doubleMarginWidth = scrollbarTheme.crossAxisMargin != null
+        ? scrollbarTheme.crossAxisMargin! * 2
+        : _kScrollbarMargin * 2;
+
+    final scrollBarThumbThikness =
+        scrollbarTheme.thickness?.resolve({MaterialState.hovered}) ??
+            _kScrollbarThickness;
+
+    return doubleMarginWidth + scrollBarThumbThikness;
   }
 }
 

--- a/lib/src/pages/layouts/yaru_page_item_list_view.dart
+++ b/lib/src/pages/layouts/yaru_page_item_list_view.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'yaru_master_detail_page.dart';
+import 'yaru_master_detail_theme.dart';
 import 'yaru_master_tile.dart';
 
 class YaruPageItemListView extends StatelessWidget {
@@ -21,10 +22,10 @@ class YaruPageItemListView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = YaruMasterDetailTheme.of(context);
     return ListView.separated(
-      separatorBuilder: (_, __) => const SizedBox(height: 6.0),
-      padding:
-          !materialTiles ? const EdgeInsets.symmetric(vertical: 8.0) : null,
+      separatorBuilder: (_, __) => SizedBox(height: theme.tileSpacing ?? 0),
+      padding: theme.listPadding,
       controller: ScrollController(),
       itemCount: length,
       itemBuilder: (context, index) => YaruMasterTileScope(

--- a/lib/src/pages/layouts/yaru_page_item_list_view.dart
+++ b/lib/src/pages/layouts/yaru_page_item_list_view.dart
@@ -3,9 +3,6 @@ import 'package:flutter/material.dart';
 import 'yaru_master_detail_page.dart';
 import 'yaru_master_tile.dart';
 
-const double _kScrollbarThickness = 8.0;
-const double _kScrollbarMargin = 2.0;
-
 class YaruPageItemListView extends StatelessWidget {
   const YaruPageItemListView({
     super.key,
@@ -24,17 +21,10 @@ class YaruPageItemListView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final scrollbarThicknessWithTrack =
-        _calcScrollbarThicknessWithTrack(context);
-
     return ListView.separated(
       separatorBuilder: (_, __) => const SizedBox(height: 6.0),
-      padding: !materialTiles
-          ? EdgeInsets.symmetric(
-              horizontal: scrollbarThicknessWithTrack,
-              vertical: 8.0,
-            )
-          : null,
+      padding:
+          !materialTiles ? const EdgeInsets.symmetric(vertical: 8.0) : null,
       controller: ScrollController(),
       itemCount: length,
       itemBuilder: (context, index) => YaruMasterTileScope(
@@ -46,19 +36,5 @@ class YaruPageItemListView extends StatelessWidget {
         ),
       ),
     );
-  }
-
-  double _calcScrollbarThicknessWithTrack(final BuildContext context) {
-    final scrollbarTheme = Theme.of(context).scrollbarTheme;
-
-    final doubleMarginWidth = scrollbarTheme.crossAxisMargin != null
-        ? scrollbarTheme.crossAxisMargin! * 2
-        : _kScrollbarMargin * 2;
-
-    final scrollBarThumbThikness =
-        scrollbarTheme.thickness?.resolve({MaterialState.hovered}) ??
-            _kScrollbarThickness;
-
-    return doubleMarginWidth + scrollBarThumbThikness;
   }
 }

--- a/lib/src/pages/layouts/yaru_portrait_layout.dart
+++ b/lib/src/pages/layouts/yaru_portrait_layout.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:yaru/yaru.dart';
 
 import 'yaru_master_detail_page.dart';
+import 'yaru_master_detail_theme.dart';
 import 'yaru_page_item_list_view.dart';
 
 class YaruPortraitLayout extends StatefulWidget {
@@ -55,11 +55,12 @@ class _YaruPortraitLayoutState extends State<YaruPortraitLayout> {
 
   @override
   Widget build(BuildContext context) {
+    final theme = YaruMasterDetailTheme.of(context);
     return WillPopScope(
       onWillPop: () async => !await _navigator.maybePop(),
       child: Theme(
         data: Theme.of(context).copyWith(
-          pageTransitionsTheme: YaruPageTransitionsTheme.horizontal,
+          pageTransitionsTheme: theme.portraitTransitions,
         ),
         child: Navigator(
           key: _navigatorKey,

--- a/lib/yaru_widgets.dart
+++ b/lib/yaru_widgets.dart
@@ -19,6 +19,7 @@ export 'src/extensions/border_radius_extension.dart';
 export 'src/pages/layouts/yaru_compact_layout.dart';
 export 'src/pages/layouts/yaru_detail_page.dart';
 export 'src/pages/layouts/yaru_master_detail_page.dart';
+export 'src/pages/layouts/yaru_master_detail_theme.dart';
 export 'src/pages/layouts/yaru_master_tile.dart';
 export 'src/pages/layouts/yaru_navigation_rail.dart';
 export 'src/pages/layouts/yaru_page_item_title.dart';


### PR DESCRIPTION
This PR implements the last item on the wish-list in #255 to give control over the internal values used for spacing, padding etc.

```dart
YaruMasterDetailTheme(
  data: YaruMasterDetailThemeData(
    breakpoint: 480,
    tileSpacing: 4,
    listPadding: EdgeInsets.only(top: 12, bottom: 34),
    // ...
  ),
  child: YaruMasterDetailPage(
    // ..
  ),
),
```