### PR TITLE
Rename YaruPageItemListView to YaruMasterListView

### DIFF
--- a/lib/src/pages/layouts/yaru_landscape_layout.dart
+++ b/lib/src/pages/layouts/yaru_landscape_layout.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'yaru_master_detail_page.dart';
 import 'yaru_master_detail_theme.dart';
-import 'yaru_page_item_list_view.dart';
+import 'yaru_master_list_view.dart';
 
 class YaruLandscapeLayout extends StatefulWidget {
   /// Creates a landscape layout
@@ -80,7 +80,7 @@ class _YaruLandscapeLayoutState extends State<YaruLandscapeLayout> {
           ),
           child: Scaffold(
             appBar: widget.appBar,
-            body: YaruPageItemListView(
+            body: YaruMasterListView(
               length: widget.length,
               selectedIndex: _selectedIndex,
               onTap: _onTap,

--- a/lib/src/pages/layouts/yaru_master_list_view.dart
+++ b/lib/src/pages/layouts/yaru_master_list_view.dart
@@ -4,8 +4,8 @@ import 'yaru_master_detail_page.dart';
 import 'yaru_master_detail_theme.dart';
 import 'yaru_master_tile.dart';
 
-class YaruPageItemListView extends StatelessWidget {
-  const YaruPageItemListView({
+class YaruMasterListView extends StatelessWidget {
+  const YaruMasterListView({
     super.key,
     required this.length,
     required this.selectedIndex,

--- a/lib/src/pages/layouts/yaru_portrait_layout.dart
+++ b/lib/src/pages/layouts/yaru_portrait_layout.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'yaru_master_detail_page.dart';
 import 'yaru_master_detail_theme.dart';
-import 'yaru_page_item_list_view.dart';
+import 'yaru_master_list_view.dart';
 
 class YaruPortraitLayout extends StatefulWidget {
   const YaruPortraitLayout({
@@ -70,7 +70,7 @@ class _YaruPortraitLayoutState extends State<YaruPortraitLayout> {
                 builder: (context) {
                   return Scaffold(
                     appBar: widget.appBar,
-                    body: YaruPageItemListView(
+                    body: YaruMasterListView(
                       length: widget.length,
                       selectedIndex: _selectedIndex,
                       onTap: _onTap,


### PR DESCRIPTION
```
YaruMasterDetailTheme
  |__YaruMasterDetailPage
       |__YaruMasterListView
       |    |__YaruMasterTile
       |__YaruDetailPage
```

No visual changes. Just renaming an internal class to match the naming scheme of the rest.