### PR TITLE
YaruCompactLayout: remove superfluous sized box

### DIFF
--- a/lib/src/pages/layouts/yaru_compact_layout.dart
+++ b/lib/src/pages/layouts/yaru_compact_layout.dart
@@ -86,25 +86,22 @@ class _YaruCompactLayoutState extends State<YaruCompactLayout> {
   }
 
   Widget _buildNavigationRail(BuildContext context, BoxConstraints constraint) {
-    return SizedBox(
-      height: MediaQuery.of(context).size.height,
-      child: SingleChildScrollView(
-        controller: _controller,
-        child: ConstrainedBox(
-          constraints: BoxConstraints(minHeight: constraint.maxHeight),
-          child: YaruNavigationRail(
-            style: widget.style,
-            selectedIndex: _index,
-            onDestinationSelected: (index) {
-              setState(() {
-                _index = index;
-                widget.onSelected?.call(index);
-              });
-            },
-            length: widget.length,
-            iconBuilder: widget.iconBuilder,
-            titleBuilder: widget.titleBuilder,
-          ),
+    return SingleChildScrollView(
+      controller: _controller,
+      child: ConstrainedBox(
+        constraints: BoxConstraints(minHeight: constraint.maxHeight),
+        child: YaruNavigationRail(
+          style: widget.style,
+          selectedIndex: _index,
+          onDestinationSelected: (index) {
+            setState(() {
+              _index = index;
+              widget.onSelected?.call(index);
+            });
+          },
+          length: widget.length,
+          iconBuilder: widget.iconBuilder,
+          titleBuilder: widget.titleBuilder,
         ),
       ),
     );


### PR DESCRIPTION
The navigation rail is in a Row that has its cross-axis alignment set to "stretch". Thus, all items in the row are vertically stretched to cover the entire height. A sized box that requests the whole window height is not necessary nor technically correct. :)

No visual changes.

![image](https://user-images.githubusercontent.com/140617/195037286-a7d5aee1-4a10-4375-a43e-149910fda3ff.png)