### PR TITLE
YaruMasterListView: create only one scroll controller

### DIFF
--- a/lib/src/pages/layouts/yaru_master_list_view.dart
+++ b/lib/src/pages/layouts/yaru_master_list_view.dart
@@ -4,7 +4,7 @@ import 'yaru_master_detail_page.dart';
 import 'yaru_master_detail_theme.dart';
 import 'yaru_master_tile.dart';
 
-class YaruMasterListView extends StatelessWidget {
+class YaruMasterListView extends StatefulWidget {
   const YaruMasterListView({
     super.key,
     required this.length,
@@ -21,19 +21,33 @@ class YaruMasterListView extends StatelessWidget {
   final bool materialTiles;
 
   @override
+  State<YaruMasterListView> createState() => _YaruMasterListViewState();
+}
+
+class _YaruMasterListViewState extends State<YaruMasterListView> {
+  final _controller = ScrollController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     final theme = YaruMasterDetailTheme.of(context);
     return ListView.separated(
       separatorBuilder: (_, __) => SizedBox(height: theme.tileSpacing ?? 0),
       padding: theme.listPadding,
-      controller: ScrollController(),
-      itemCount: length,
+      controller: _controller,
+      itemCount: widget.length,
       itemBuilder: (context, index) => YaruMasterTileScope(
         index: index,
-        selected: index == selectedIndex,
-        onTap: () => onTap(index),
+        selected: index == widget.selectedIndex,
+        onTap: () => widget.onTap(index),
         child: Builder(
-          builder: (context) => builder(context, index, index == selectedIndex),
+          builder: (context) =>
+              widget.builder(context, index, index == widget.selectedIndex),
         ),
       ),
     );


### PR DESCRIPTION
Don't create a new scroll controller every time the widget is rebuilt.