### PR TITLE
MaterDetails: add tiny selected tile background animation

### DIFF
--- a/lib/src/pages/layouts/yaru_master_tile.dart
+++ b/lib/src/pages/layouts/yaru_master_tile.dart
@@ -4,6 +4,7 @@ import '../../constants.dart';
 
 const double _kScrollbarThickness = 8.0;
 const double _kScrollbarMargin = 2.0;
+const Duration _kSelectedTileAnimationDuration = Duration(milliseconds: 250);
 
 class YaruMasterTile extends StatelessWidget {
   const YaruMasterTile({
@@ -32,7 +33,8 @@ class YaruMasterTile extends StatelessWidget {
 
     return Padding(
       padding: EdgeInsets.symmetric(horizontal: scrollbarThicknessWithTrack),
-      child: DecoratedBox(
+      child: AnimatedContainer(
+        duration: _kSelectedTileAnimationDuration,
         decoration: BoxDecoration(
           borderRadius:
               const BorderRadius.all(Radius.circular(kYaruButtonRadius)),


### PR DESCRIPTION
We have page animation, so the selected/unselected background change looks a bit rough without animation now imo.

**Before:**

https://user-images.githubusercontent.com/36476595/195073964-ac87bee8-8e24-4f4c-b2fc-c0bdd84a78cb.mp4

**After:**

https://user-images.githubusercontent.com/36476595/195073959-5e0d6d8a-2e5e-4c2c-90bf-aab940011ea0.mp4







