### PR TITLE
set separate color for subtitle in YaruMasterTile

### DIFF
--- a/lib/src/pages/layouts/yaru_master_tile.dart
+++ b/lib/src/pages/layouts/yaru_master_tile.dart
@@ -41,7 +41,6 @@ class YaruMasterTile extends StatelessWidget {
               : null,
         ),
         child: ListTile(
-          textColor: Theme.of(context).colorScheme.onSurface,
           selectedColor: Theme.of(context).colorScheme.onSurface,
           iconColor: Theme.of(context).colorScheme.onSurface.withOpacity(0.8),
           visualDensity: const VisualDensity(horizontal: -4, vertical: -4),
@@ -49,8 +48,8 @@ class YaruMasterTile extends StatelessWidget {
             borderRadius: BorderRadius.all(Radius.circular(kYaruButtonRadius)),
           ),
           leading: leading,
-          title: _buildChild(title),
-          subtitle: _buildChild(subtitle),
+          title: _titleStyle(context, title),
+          subtitle: _subTitleStyle(context, subtitle),
           trailing: trailing,
           selected: isSelected,
           onTap: () {
@@ -63,7 +62,7 @@ class YaruMasterTile extends StatelessWidget {
     );
   }
 
-  Widget? _buildChild(Widget? child) {
+  Widget? _titleStyle(BuildContext context, Widget? child) {
     if (child == null) {
       return child;
     }
@@ -72,6 +71,20 @@ class YaruMasterTile extends StatelessWidget {
       child: child,
       maxLines: 1,
       overflow: TextOverflow.ellipsis,
+      style: TextStyle(color: Theme.of(context).colorScheme.onSurface),
+    );
+  }
+
+  Widget? _subTitleStyle(BuildContext context, Widget? child) {
+    if (child == null) {
+      return child;
+    }
+
+    return DefaultTextStyle.merge(
+      child: child,
+      maxLines: 1,
+      overflow: TextOverflow.ellipsis,
+      style: TextStyle(color: Theme.of(context).textTheme.caption!.color),
     );
   }
 


### PR DESCRIPTION
The subtitle color was overridden by setting a uniform `textColor` in `YaruMasterTile`'s `ListTile` - this commit restores the original look of `ListTile`

## Pull request checklist

- [x] I added a before/after/light/dark table if the changes I made could change the components look

<!-- Remove this if your change does not touch components -->
| |Before|After|
|-|-|-|
|Light| ![image](https://user-images.githubusercontent.com/113362648/195100756-09e0d8d6-daec-4b01-87b3-5d1f6d641080.png)  | ![image](https://user-images.githubusercontent.com/113362648/195101070-b52dbdfe-ed6e-4af1-bba4-d74a41e60570.png) |
|Dark| ![image](https://user-images.githubusercontent.com/113362648/195100631-6ea41ede-c99c-4b94-aa78-b07c60144159.png)  | ![image](https://user-images.githubusercontent.com/113362648/195100947-495b8b04-fa89-4a72-870b-ee8766c5732f.png) |