### PR TITLE
YaruLandscapeLayout: use DividerTheme

### DIFF
--- a/lib/src/pages/layouts/yaru_landscape_layout.dart
+++ b/lib/src/pages/layouts/yaru_landscape_layout.dart
@@ -123,8 +123,6 @@ class _YaruLandscapeLayoutState extends State<YaruLandscapeLayout> {
     );
   }
 
-  Color get _separatorColor => Colors.black.withOpacity(0.1);
-
   Widget _maybeBuildGlobalMouseRegion(Widget child) {
     if (widget.allowLeftPaneResize) {
       return MouseRegion(
@@ -154,10 +152,9 @@ class _YaruLandscapeLayoutState extends State<YaruLandscapeLayout> {
   }
 
   Widget _buildVerticalSeparator() {
-    return VerticalDivider(
+    return const VerticalDivider(
       thickness: 1,
       width: 1,
-      color: _separatorColor,
     );
   }
 
@@ -192,8 +189,9 @@ class _YaruLandscapeLayoutState extends State<YaruLandscapeLayout> {
     return Positioned(
       child: AnimatedContainer(
         duration: _kLeftPaneResizingRegionAnimationDuration,
-        color:
-            _isHovering || _isDragging ? _separatorColor : Colors.transparent,
+        color: _isHovering || _isDragging
+            ? DividerTheme.of(context).color
+            : Colors.transparent,
         child: MouseRegion(
           cursor: SystemMouseCursors.resizeColumn,
           onEnter: (event) => setState(() {


### PR DESCRIPTION
Use DividerTheme instead of hardcoded color to be aligned with the compact layout.

No visual change.