### PR TITLE
YaruCompactLayout: replace icon/titleBuilder with itemBuilder

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -99,16 +99,16 @@ class _CompactPage extends StatelessWidget {
     final pageItems = [configItem] + examplePageItems;
 
     return YaruCompactLayout(
-      style: width > 1000
-          ? YaruNavigationRailStyle.labelledExtended
-          : width > 500
-              ? YaruNavigationRailStyle.labelled
-              : YaruNavigationRailStyle.compact,
       length: pageItems.length,
-      iconBuilder: (context, index, selected) =>
-          pageItems[index].iconBuilder(context, selected),
-      titleBuilder: (context, index, selected) =>
-          pageItems[index].titleBuilder(context),
+      itemBuilder: (context, index, selected) => YaruNavigationRailItem(
+        icon: pageItems[index].iconBuilder(context, selected),
+        label: pageItems[index].titleBuilder(context),
+        style: width > 1000
+            ? YaruNavigationRailStyle.labelledExtended
+            : width > 500
+                ? YaruNavigationRailStyle.labelled
+                : YaruNavigationRailStyle.compact,
+      ),
       pageBuilder: (context, index) => pageItems[index].pageBuilder(context),
     );
   }

--- a/lib/src/pages/layouts/yaru_compact_layout.dart
+++ b/lib/src/pages/layouts/yaru_compact_layout.dart
@@ -14,10 +14,8 @@ class YaruCompactLayout extends StatefulWidget {
   const YaruCompactLayout({
     super.key,
     required this.length,
-    required this.iconBuilder,
-    required this.titleBuilder,
+    required this.itemBuilder,
     required this.pageBuilder,
-    this.style = YaruNavigationRailStyle.compact,
     this.initialIndex = 0,
     this.onSelected,
   });
@@ -25,17 +23,11 @@ class YaruCompactLayout extends StatefulWidget {
   /// The total number of pages.
   final int length;
 
-  /// A builder that is called for each page to build its icon.
-  final YaruCompactLayoutBuilder iconBuilder;
-
   /// A builder that is called for each page to build its title.
-  final YaruCompactLayoutBuilder titleBuilder;
+  final YaruCompactLayoutBuilder itemBuilder;
 
   /// A builder that is called for each page to build its content.
   final IndexedWidgetBuilder pageBuilder;
-
-  /// Define the navigation rail style, see [YaruNavigationRailStyle]
-  final YaruNavigationRailStyle style;
 
   /// The index of the [YaruPageItem] that is selected from [pageItems]
   final int initialIndex;
@@ -92,7 +84,6 @@ class _YaruCompactLayoutState extends State<YaruCompactLayout> {
       child: ConstrainedBox(
         constraints: BoxConstraints(minHeight: constraint.maxHeight),
         child: YaruNavigationRail(
-          style: widget.style,
           selectedIndex: _index,
           onDestinationSelected: (index) {
             setState(() {
@@ -101,8 +92,7 @@ class _YaruCompactLayoutState extends State<YaruCompactLayout> {
             });
           },
           length: widget.length,
-          iconBuilder: widget.iconBuilder,
-          titleBuilder: widget.titleBuilder,
+          itemBuilder: widget.itemBuilder,
         ),
       ),
     );

--- a/lib/src/pages/layouts/yaru_compact_layout.dart
+++ b/lib/src/pages/layouts/yaru_compact_layout.dart
@@ -23,7 +23,10 @@ class YaruCompactLayout extends StatefulWidget {
   /// The total number of pages.
   final int length;
 
-  /// A builder that is called for each page to build its title.
+  /// A builder that is called for each page to build its navigation rail item.
+  ///
+  /// See also:
+  ///  * [YaruNavigationRailItem]
   final YaruCompactLayoutBuilder itemBuilder;
 
   /// A builder that is called for each page to build its content.

--- a/lib/src/pages/layouts/yaru_navigation_rail.dart
+++ b/lib/src/pages/layouts/yaru_navigation_rail.dart
@@ -1,30 +1,15 @@
 import 'package:flutter/material.dart';
-import '../../../yaru_widgets.dart';
 
-/// Defines the look of a [YaruNavigationRail]
-enum YaruNavigationRailStyle {
-  /// Will only show icons
-  compact,
-
-  /// Will show both icons and labels vertically
-  labelled,
-
-  /// Will show both icons and labels horizontally
-  labelledExtended,
-}
-
-const _kSizeAnimationDuration = Duration(milliseconds: 200);
-const _kSelectedIconAnimationDuration = Duration(milliseconds: 250);
+import 'yaru_compact_layout.dart';
+import 'yaru_navigation_rail_item.dart';
 
 class YaruNavigationRail extends StatelessWidget {
   const YaruNavigationRail({
     super.key,
     required this.length,
-    required this.iconBuilder,
-    required this.titleBuilder,
+    required this.itemBuilder,
     required this.selectedIndex,
     required this.onDestinationSelected,
-    this.style = YaruNavigationRailStyle.compact,
   })  : assert(length >= 2),
         assert(
           selectedIndex == null ||
@@ -34,11 +19,8 @@ class YaruNavigationRail extends StatelessWidget {
   /// The total number of pages.
   final int length;
 
-  /// A builder that is called for each page to build its icon.
-  final YaruCompactLayoutBuilder iconBuilder;
-
-  /// A builder that is called for each page to build its title.
-  final YaruCompactLayoutBuilder titleBuilder;
+  /// A builder that is called for each page to build its navigation rail item.
+  final YaruCompactLayoutBuilder itemBuilder;
 
   /// The index into [destinations] for the current selected
   /// [YaruPageItem] or null if no destination is selected.
@@ -51,9 +33,6 @@ class YaruNavigationRail extends StatelessWidget {
   /// `setState` to rebuild the navigation rail with the new [selectedIndex].
   final ValueChanged<int>? onDestinationSelected;
 
-  /// Define the navigation rail style, see [YaruNavigationRailStyle]
-  final YaruNavigationRailStyle style;
-
   @override
   Widget build(BuildContext context) {
     return Padding(
@@ -61,191 +40,20 @@ class YaruNavigationRail extends StatelessWidget {
       child: Column(
         children: <Widget>[
           for (int i = 0; i < length; i += 1)
-            _YaruNavigationRailItem(
-              i,
-              i == selectedIndex,
-              iconBuilder,
-              titleBuilder,
-              onDestinationSelected,
-              style,
+            YaruNavigationRailItemScope(
+              index: i,
+              selected: i == selectedIndex,
+              onTap: () => onDestinationSelected?.call(i),
+              child: Builder(
+                builder: (context) => itemBuilder(
+                  context,
+                  i,
+                  i == selectedIndex,
+                ),
+              ),
             )
         ],
       ),
     );
-  }
-}
-
-class _YaruNavigationRailItem extends StatefulWidget {
-  const _YaruNavigationRailItem(
-    this.index,
-    this.selected,
-    this.iconBuilder,
-    this.titleBuilder,
-    this.onDestinationSelected,
-    this.style,
-  );
-
-  final int index;
-  final bool selected;
-  final YaruCompactLayoutBuilder iconBuilder;
-  final YaruCompactLayoutBuilder titleBuilder;
-  final ValueChanged<int>? onDestinationSelected;
-  final YaruNavigationRailStyle style;
-
-  @override
-  State<_YaruNavigationRailItem> createState() =>
-      _YaruNavigationRailItemState();
-}
-
-class _YaruNavigationRailItemState extends State<_YaruNavigationRailItem> {
-  YaruNavigationRailStyle? oldStyle;
-
-  @override
-  void didUpdateWidget(_YaruNavigationRailItem oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (widget.style != oldWidget.style) {
-      oldStyle = oldWidget.style;
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return _buildSizedContainer(
-      Material(
-        child: InkWell(
-          onTap: () {
-            if (widget.onDestinationSelected != null) {
-              widget.onDestinationSelected!.call(widget.index);
-            }
-          },
-          child: Center(
-            child: Padding(
-              padding: EdgeInsets.symmetric(
-                vertical:
-                    widget.style == YaruNavigationRailStyle.labelledExtended
-                        ? 10
-                        : 5,
-                horizontal:
-                    widget.style == YaruNavigationRailStyle.labelledExtended
-                        ? 8
-                        : 5,
-              ),
-              child: _buildColumnOrRow([
-                _buildIcon(context),
-                if (widget.style != YaruNavigationRailStyle.compact) ...[
-                  _buildGap(),
-                  _buildLabel(context),
-                ]
-              ]),
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-
-  Alignment get _alignement {
-    return widget.style == YaruNavigationRailStyle.labelledExtended ||
-            oldStyle == YaruNavigationRailStyle.labelledExtended
-        ? Alignment.centerLeft
-        : Alignment.topCenter;
-  }
-
-  double get _width {
-    switch (widget.style) {
-      case YaruNavigationRailStyle.labelledExtended:
-        return 250;
-      case YaruNavigationRailStyle.labelled:
-        return 100;
-      case YaruNavigationRailStyle.compact:
-        return 60;
-    }
-  }
-
-  Widget _buildSizedContainer(Widget child) {
-    return AnimatedSize(
-      duration: _kSizeAnimationDuration,
-      alignment: _alignement,
-      child: Align(
-        alignment: _alignement,
-        child: SizedBox(
-          width: _width,
-          child: child,
-        ),
-      ),
-    );
-  }
-
-  Widget _buildColumnOrRow(List<Widget> children) {
-    const mainAxisAlignment = MainAxisAlignment.start;
-
-    if (widget.style == YaruNavigationRailStyle.labelledExtended) {
-      return Row(
-        mainAxisAlignment: mainAxisAlignment,
-        children: children,
-      );
-    }
-
-    return Column(
-      mainAxisAlignment: mainAxisAlignment,
-      children: children,
-    );
-  }
-
-  Widget _buildIcon(BuildContext context) {
-    return AnimatedContainer(
-      duration: _kSelectedIconAnimationDuration,
-      decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(100),
-        color: widget.selected
-            ? Theme.of(context).colorScheme.onSurface.withOpacity(.1)
-            : null,
-      ),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(
-          vertical: 2,
-          horizontal: 10,
-        ),
-        child: widget.iconBuilder(
-          context,
-          widget.index,
-          widget.selected,
-        ),
-      ),
-    );
-  }
-
-  Widget _buildGap() {
-    if (widget.style == YaruNavigationRailStyle.labelledExtended) {
-      return const SizedBox(width: 10);
-    }
-
-    return const SizedBox(height: 5);
-  }
-
-  Widget _buildLabel(BuildContext context) {
-    var label = widget.titleBuilder(context, widget.index, widget.selected);
-
-    if (label is YaruPageItemTitle) {
-      label = DefaultTextStyle.merge(
-        child: label,
-        style: TextStyle(
-          fontSize: widget.style == YaruNavigationRailStyle.labelledExtended
-              ? 13
-              : 12,
-          fontWeight: FontWeight.w500,
-        ),
-        overflow: TextOverflow.ellipsis,
-        softWrap: true,
-        textAlign: widget.style == YaruNavigationRailStyle.labelledExtended
-            ? null
-            : TextAlign.center,
-        maxLines: 1,
-      );
-    }
-
-    return widget.style == YaruNavigationRailStyle.labelledExtended
-        ? Expanded(child: label)
-        : label;
   }
 }

--- a/lib/src/pages/layouts/yaru_navigation_rail_item.dart
+++ b/lib/src/pages/layouts/yaru_navigation_rail_item.dart
@@ -1,0 +1,213 @@
+import 'package:flutter/material.dart';
+
+/// Defines the look of a [YaruNavigationRailItem]
+enum YaruNavigationRailStyle {
+  /// Will only show icons
+  compact,
+
+  /// Will show both icons and labels vertically
+  labelled,
+
+  /// Will show both icons and labels horizontally
+  labelledExtended,
+}
+
+const _kSizeAnimationDuration = Duration(milliseconds: 200);
+const _kSelectedIconAnimationDuration = Duration(milliseconds: 250);
+
+class YaruNavigationRailItem extends StatefulWidget {
+  const YaruNavigationRailItem({
+    super.key,
+    this.selected,
+    required this.icon,
+    required this.label,
+    this.onTap,
+    required this.style,
+  });
+
+  final bool? selected;
+  final Widget icon;
+  final Widget label;
+  final VoidCallback? onTap;
+  final YaruNavigationRailStyle style;
+
+  @override
+  State<YaruNavigationRailItem> createState() => _YaruNavigationRailItemState();
+}
+
+class _YaruNavigationRailItemState extends State<YaruNavigationRailItem> {
+  YaruNavigationRailStyle? oldStyle;
+
+  @override
+  void didUpdateWidget(YaruNavigationRailItem oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.style != oldWidget.style) {
+      oldStyle = oldWidget.style;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return _buildSizedContainer(
+      Material(
+        child: InkWell(
+          onTap: () {
+            final scope = YaruNavigationRailItemScope.maybeOf(context);
+            scope?.onTap();
+            widget.onTap?.call();
+          },
+          child: Center(
+            child: Padding(
+              padding: EdgeInsets.symmetric(
+                vertical:
+                    widget.style == YaruNavigationRailStyle.labelledExtended
+                        ? 10
+                        : 5,
+                horizontal:
+                    widget.style == YaruNavigationRailStyle.labelledExtended
+                        ? 8
+                        : 5,
+              ),
+              child: _buildColumnOrRow([
+                _buildIcon(context),
+                if (widget.style != YaruNavigationRailStyle.compact) ...[
+                  _buildGap(),
+                  _buildLabel(context),
+                ]
+              ]),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  bool get _selected {
+    return widget.selected ??
+        YaruNavigationRailItemScope.maybeOf(context)?.selected == true;
+  }
+
+  Alignment get _alignement {
+    return widget.style == YaruNavigationRailStyle.labelledExtended ||
+            oldStyle == YaruNavigationRailStyle.labelledExtended
+        ? Alignment.centerLeft
+        : Alignment.topCenter;
+  }
+
+  double get _width {
+    switch (widget.style) {
+      case YaruNavigationRailStyle.labelledExtended:
+        return 250;
+      case YaruNavigationRailStyle.labelled:
+        return 100;
+      case YaruNavigationRailStyle.compact:
+        return 60;
+    }
+  }
+
+  Widget _buildSizedContainer(Widget child) {
+    return AnimatedSize(
+      duration: _kSizeAnimationDuration,
+      alignment: _alignement,
+      child: Align(
+        alignment: _alignement,
+        child: SizedBox(
+          width: _width,
+          child: child,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildColumnOrRow(List<Widget> children) {
+    const mainAxisAlignment = MainAxisAlignment.start;
+
+    if (widget.style == YaruNavigationRailStyle.labelledExtended) {
+      return Row(
+        mainAxisAlignment: mainAxisAlignment,
+        children: children,
+      );
+    }
+
+    return Column(
+      mainAxisAlignment: mainAxisAlignment,
+      children: children,
+    );
+  }
+
+  Widget _buildIcon(BuildContext context) {
+    return AnimatedContainer(
+      duration: _kSelectedIconAnimationDuration,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(100),
+        color: _selected
+            ? Theme.of(context).colorScheme.onSurface.withOpacity(.1)
+            : null,
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          vertical: 2,
+          horizontal: 10,
+        ),
+        child: widget.icon,
+      ),
+    );
+  }
+
+  Widget _buildGap() {
+    if (widget.style == YaruNavigationRailStyle.labelledExtended) {
+      return const SizedBox(width: 10);
+    }
+
+    return const SizedBox(height: 5);
+  }
+
+  Widget _buildLabel(BuildContext context) {
+    final label = DefaultTextStyle.merge(
+      child: widget.label,
+      style: TextStyle(
+        fontSize:
+            widget.style == YaruNavigationRailStyle.labelledExtended ? 13 : 12,
+        fontWeight: FontWeight.w500,
+      ),
+      overflow: TextOverflow.ellipsis,
+      softWrap: true,
+      textAlign: widget.style == YaruNavigationRailStyle.labelledExtended
+          ? null
+          : TextAlign.center,
+      maxLines: 1,
+    );
+
+    return widget.style == YaruNavigationRailStyle.labelledExtended
+        ? Expanded(child: label)
+        : label;
+  }
+}
+
+class YaruNavigationRailItemScope extends InheritedWidget {
+  const YaruNavigationRailItemScope({
+    super.key,
+    required super.child,
+    required this.index,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final int index;
+  final bool selected;
+  final VoidCallback onTap;
+
+  static YaruNavigationRailItemScope of(BuildContext context) {
+    return maybeOf(context)!;
+  }
+
+  static YaruNavigationRailItemScope? maybeOf(BuildContext context) {
+    return context
+        .dependOnInheritedWidgetOfExactType<YaruNavigationRailItemScope>();
+  }
+
+  @override
+  bool updateShouldNotify(YaruNavigationRailItemScope oldWidget) {
+    return selected != oldWidget.selected || index != oldWidget.index;
+  }
+}

--- a/lib/yaru_widgets.dart
+++ b/lib/yaru_widgets.dart
@@ -22,6 +22,7 @@ export 'src/pages/layouts/yaru_master_detail_page.dart';
 export 'src/pages/layouts/yaru_master_detail_theme.dart';
 export 'src/pages/layouts/yaru_master_tile.dart';
 export 'src/pages/layouts/yaru_navigation_rail.dart';
+export 'src/pages/layouts/yaru_navigation_rail_item.dart';
 export 'src/pages/layouts/yaru_page_item_title.dart';
 // Pages
 export 'src/pages/yaru_section.dart';


### PR DESCRIPTION
And expose YaruNavigationRailItem as the recommended default building block. This is essentially the same as #252 for YaruMasterDetailPage.

### Before
```dart
YaruCompactLayout(
  length: 5,
  iconBuilder: (context, index, selected) => Icon(...),
  titleBuilder: (context, index, selected) => Text(...),
  pageBuilder: (context, index) => ...
  style: width > 620 ... : ...
)
```

### After
```dart
YaruCompactLayout(
  length: 5,
  itemBuilder: (context, index, selected) => YaruNavigationRailItem(
    icon: Icon(...),
    label: Text(...)
    style: width > 620 ... : ...
  ),
  pageBuilder: (context, index) => ...
)
```