### PR TITLE
Re-add tab background

### DIFF
--- a/lib/src/pages/yaru_tabbed_page.dart
+++ b/lib/src/pages/yaru_tabbed_page.dart
@@ -89,29 +89,22 @@ class _YaruTabbedPageState extends State<YaruTabbedPage>
             decoration: BoxDecoration(
               borderRadius: BorderRadius.circular(kYaruContainerRadius),
             ),
-            child: Theme(
-              data: ThemeData().copyWith(
-                splashColor: Colors.transparent,
-                hoverColor: Colors.transparent,
-                highlightColor: Colors.transparent,
+            child: TabBar(
+              controller: tabController,
+              labelColor: Theme.of(context).colorScheme.onSurface,
+              indicator: BoxDecoration(
+                borderRadius: BorderRadius.circular(kYaruContainerRadius),
+                color: Theme.of(context).colorScheme.onSurface.withOpacity(0.1),
               ),
-              child: TabBar(
-                controller: tabController,
-                labelColor: Theme.of(context).colorScheme.onSurface,
-                indicator: BoxDecoration(
-                  borderRadius: BorderRadius.circular(kYaruContainerRadius),
-                  color:
-                      Theme.of(context).colorScheme.onSurface.withOpacity(0.1),
-                ),
-                onTap: widget.onTap,
-                tabs: [
-                  for (var i = 0; i < widget.views.length; i++)
-                    Tab(
-                      text: titlesDoNotFit() ? null : widget.tabTitles[i],
-                      icon: widget.tabIcons[i],
-                    )
-                ],
-              ),
+              splashBorderRadius: BorderRadius.circular(kYaruContainerRadius),
+              onTap: widget.onTap,
+              tabs: [
+                for (var i = 0; i < widget.views.length; i++)
+                  Tab(
+                    text: titlesDoNotFit() ? null : widget.tabTitles[i],
+                    icon: widget.tabIcons[i],
+                  )
+              ],
             ),
           ),
         ),


### PR DESCRIPTION
We can now set the `splashBorderRadius` :tada: 
But the font size changed, it was because we was using a theme which wasn't extend the one from `context` (my fault).

If we want to keep the same look, I suppose we should fix this in `yaru.dart`?

**Before:**

https://user-images.githubusercontent.com/36476595/195403276-137d830e-a014-461b-8df2-3ff3b62e6c73.mp4

**After:**

https://user-images.githubusercontent.com/36476595/195403312-b9c0ff45-e223-447b-b24c-f9aae7a08284.mp4

https://user-images.githubusercontent.com/36476595/195403323-c0227ae4-fc3e-4d1a-a1bd-f9896a395f60.mp4

Fixes #50