### PR TITLE
Replace all Material icons with Yaru ones

### DIFF
--- a/example/lib/pages/carousel_page.dart
+++ b/example/lib/pages/carousel_page.dart
@@ -28,8 +28,6 @@ class _CarouselPageState extends State<CarouselPage> {
               children: _getCarouselChildren(),
               height: 400,
               navigationControls: true,
-              previousIcon: const Icon(YaruIcons.go_previous),
-              nextIcon: const Icon(YaruIcons.go_next),
             ),
           ],
         ),

--- a/example/lib/pages/expandable_page.dart
+++ b/example/lib/pages/expandable_page.dart
@@ -19,7 +19,6 @@ class ExpandablePage extends StatelessWidget {
             'Lorem ipsum dolor sit amet',
             style: TextStyle(fontWeight: FontWeight.bold),
           ),
-          expandIcon: Icon(YaruIcons.pan_end),
         ),
         YaruExpandable(
           isExpanded: true,
@@ -33,7 +32,6 @@ class ExpandablePage extends StatelessWidget {
             'Lorem ipsum dolor sit amet',
             style: TextStyle(fontWeight: FontWeight.bold),
           ),
-          expandIcon: Icon(YaruIcons.pan_end),
         )
       ],
     );

--- a/example/lib/pages/expandable_page.dart
+++ b/example/lib/pages/expandable_page.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
 const _lorem =

--- a/lib/src/utilities/yaru_carousel.dart
+++ b/lib/src/utilities/yaru_carousel.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
+import 'package:yaru_icons/yaru_icons.dart';
 
 class YaruCarousel extends StatefulWidget {
   const YaruCarousel({
@@ -131,12 +132,12 @@ class _YaruCarouselState extends State<YaruCarousel> {
             _buildNavigationButton(
               Alignment.centerLeft,
               _isFirstPage() ? null : () => widget.controller.previousPage(),
-              widget.previousIcon ?? const Icon(Icons.arrow_back),
+              widget.previousIcon ?? const Icon(YaruIcons.go_previous),
             ),
             _buildNavigationButton(
               Alignment.centerRight,
               _isLastPage() ? null : () => widget.controller.nextPage(),
-              widget.nextIcon ?? const Icon(Icons.arrow_forward),
+              widget.nextIcon ?? const Icon(YaruIcons.go_next),
             ),
           ],
         ),

--- a/lib/src/utilities/yaru_expandable.dart
+++ b/lib/src/utilities/yaru_expandable.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:yaru_icons/yaru_icons.dart';
 import '../../yaru_widgets.dart';
 
 const _kAnimationDuration = Duration(milliseconds: 250);
@@ -67,7 +68,7 @@ class _YaruExpandableState extends State<YaruExpandable> {
                 turns: _isExpanded ? .25 : 0,
                 duration: _kAnimationDuration,
                 curve: _kAnimationCurve,
-                child: widget.expandIcon ?? const Icon(Icons.arrow_right),
+                child: widget.expandIcon ?? const Icon(YaruIcons.pan_end),
               ),
             ),
           ],


### PR DESCRIPTION
**Before:**

![Capture d’écran du 2022-10-12 21-08-29](https://user-images.githubusercontent.com/36476595/195427774-cc934363-6973-40c2-9b09-1b1be2f417f3.png)

![Capture d’écran du 2022-10-12 21-08-39](https://user-images.githubusercontent.com/36476595/195427779-dfcd7784-bb1b-41ca-bcf3-e1bf15f888d3.png)

**After:*

![Capture d’écran du 2022-10-12 21-07-39](https://user-images.githubusercontent.com/36476595/195427819-d533b3aa-ea41-40fa-9cf2-670349e4a78e.png)
![Capture d’écran du 2022-10-12 21-07-53](https://user-images.githubusercontent.com/36476595/195427823-34069dc0-6b49-4975-b929-8b2c25430659.png)


Fixes #288