### PR TITLE
YaruCheckButton & YaruRadioButton: add missing behavioral properties

### DIFF
--- a/lib/src/controls/yaru_check_button.dart
+++ b/lib/src/controls/yaru_check_button.dart
@@ -12,6 +12,9 @@ class YaruCheckButton extends StatelessWidget {
     required this.title,
     this.subtitle,
     this.contentPadding,
+    this.tristate = false,
+    this.autofocus = false,
+    this.focusNode,
   });
 
   /// See [Checkbox.value]
@@ -29,6 +32,15 @@ class YaruCheckButton extends StatelessWidget {
   /// See [YaruToggleButton.contentPadding]
   final EdgeInsetsGeometry? contentPadding;
 
+  /// See [Checkbox.tristate].
+  final bool tristate;
+
+  /// See [Checkbox.focusNode].
+  final FocusNode? focusNode;
+
+  /// See [Checkbox.autofocus].
+  final bool autofocus;
+
   @override
   Widget build(BuildContext context) {
     return YaruToggleButton(
@@ -41,6 +53,9 @@ class YaruCheckButton extends StatelessWidget {
           child: Checkbox(
             value: value,
             onChanged: onChanged,
+            tristate: tristate,
+            focusNode: focusNode,
+            autofocus: autofocus,
           ),
         ),
       ),

--- a/lib/src/controls/yaru_radio_button.dart
+++ b/lib/src/controls/yaru_radio_button.dart
@@ -13,6 +13,9 @@ class YaruRadioButton<T> extends StatelessWidget {
     required this.title,
     this.subtitle,
     this.contentPadding,
+    this.toggleable = false,
+    this.autofocus = false,
+    this.focusNode,
   });
 
   /// See [Radio.value]
@@ -33,6 +36,15 @@ class YaruRadioButton<T> extends StatelessWidget {
   /// See [YaruToggleButton.contentPadding]
   final EdgeInsetsGeometry? contentPadding;
 
+  /// See [Radio.toggleable].
+  final bool toggleable;
+
+  /// See [Radio.focusNode].
+  final FocusNode? focusNode;
+
+  /// See [Radio.autofocus].
+  final bool autofocus;
+
   @override
   Widget build(BuildContext context) {
     return YaruToggleButton(
@@ -46,6 +58,9 @@ class YaruRadioButton<T> extends StatelessWidget {
             value: value,
             groupValue: groupValue,
             onChanged: onChanged,
+            toggleable: toggleable,
+            focusNode: focusNode,
+            autofocus: autofocus,
           ),
         ),
       ),


### PR DESCRIPTION
This PR exposes a few missing properties that general-purpose checks and radios must have.