### PR TITLE
YaruNavigationRailItem: add tooltip

### DIFF
--- a/example/lib/example_page_items.dart
+++ b/example/lib/example_page_items.dart
@@ -19,11 +19,13 @@ import 'pages/tile_page.dart';
 class PageItem {
   const PageItem({
     required this.titleBuilder,
+    required this.tooltipMessage,
     required this.pageBuilder,
     required this.iconBuilder,
   });
 
   final WidgetBuilder titleBuilder;
+  final String tooltipMessage;
   final WidgetBuilder pageBuilder;
   final Widget Function(BuildContext context, bool selected) iconBuilder;
 }
@@ -31,6 +33,7 @@ class PageItem {
 final examplePageItems = <PageItem>[
   PageItem(
     titleBuilder: (context) => const Text('YaruBanner'),
+    tooltipMessage: 'YaruBanner',
     pageBuilder: (context) => const BannerPage(),
     iconBuilder: (context, selected) => selected
         ? const Icon(YaruIcons.image_filled)
@@ -38,74 +41,88 @@ final examplePageItems = <PageItem>[
   ),
   PageItem(
     titleBuilder: (context) => const Text('YaruCarousel'),
+    tooltipMessage: 'YaruCarousel',
     pageBuilder: (_) => const CarouselPage(),
     iconBuilder: (context, selected) => const Icon(YaruIcons.refresh),
   ),
   PageItem(
     titleBuilder: (context) => const Text('YaruCheckButton'),
+    tooltipMessage: 'YaruCheckButton',
     pageBuilder: (context) => const CheckButtonPage(),
     iconBuilder: (context, selected) =>
         const Icon(YaruIcons.checkbox_button_checked),
   ),
   PageItem(
     titleBuilder: (context) => const Text('YaruColorDisk'),
+    tooltipMessage: 'YaruColorDisk',
     pageBuilder: (context) => const ColorDiskPage(),
     iconBuilder: (context, selected) => const Icon(YaruIcons.color_select),
   ),
   PageItem(
     titleBuilder: (context) => const Text('YaruDraggable'),
+    tooltipMessage: 'YaruDraggable',
     pageBuilder: (context) => const DraggablePage(),
     iconBuilder: (context, selected) => const Icon(YaruIcons.drag_handle),
   ),
   PageItem(
     titleBuilder: (context) => const Text('YaruExpandable'),
+    tooltipMessage: 'YaruExpandable',
     iconBuilder: (context, selected) => const Icon(YaruIcons.pan_down),
     pageBuilder: (_) => const ExpandablePage(),
   ),
   PageItem(
     titleBuilder: (context) => const Text('YaruIconButton'),
+    tooltipMessage: 'YaruIconButton',
     iconBuilder: (context, selected) => const Icon(YaruIcons.app_grid),
     pageBuilder: (_) => const IconButtonPage(),
   ),
   PageItem(
     titleBuilder: (context) => const Text('YaruOptionButton'),
+    tooltipMessage: 'YaruOptionButton',
     iconBuilder: (context, selected) => const Icon(YaruIcons.settings),
     pageBuilder: (_) => const OptionButtonPage(),
   ),
   PageItem(
     titleBuilder: (context) => const Text('YaruProgressIndicator'),
+    tooltipMessage: 'YaruProgressIndicator',
     iconBuilder: (context, selected) => const Icon(YaruIcons.download),
     pageBuilder: (_) => const ProgressIndicatorPage(),
   ),
   PageItem(
     titleBuilder: (context) => const Text('YaruRadioButton'),
+    tooltipMessage: 'YaruRadioButton',
     pageBuilder: (context) => const RadioButtonPage(),
     iconBuilder: (context, selected) =>
         const Icon(YaruIcons.radio_button_checked),
   ),
   PageItem(
     titleBuilder: (context) => const Text('YaruSection'),
+    tooltipMessage: 'YaruSection',
     iconBuilder: (context, selected) => const Icon(YaruIcons.window),
     pageBuilder: (_) => const SectionPage(),
   ),
   PageItem(
     titleBuilder: (context) => const Text('YaruSelectableContainer'),
+    tooltipMessage: 'YaruSelectableContainer',
     iconBuilder: (context, selected) => const Icon(YaruIcons.selection),
     pageBuilder: (_) => const SelectableContainerPage(),
   ),
   PageItem(
     titleBuilder: (context) => const Text('YaruTabbedPage'),
+    tooltipMessage: 'YaruTabbedPage',
     pageBuilder: (_) => const TabbedPagePage(),
     iconBuilder: (context, selected) => const Icon(YaruIcons.tab_new),
   ),
   PageItem(
     titleBuilder: (context) => const Text('YaruTile'),
+    tooltipMessage: 'YaruTile',
     iconBuilder: (context, selected) =>
         const Icon(YaruIcons.format_unordered_list),
     pageBuilder: (_) => const TilePage(),
   ),
   PageItem(
     titleBuilder: (context) => const Text('YaruDialogTitle'),
+    tooltipMessage: 'YaruDialogTitle',
     iconBuilder: (context, selected) => selected
         ? const Icon(YaruIcons.information_filled)
         : const Icon(YaruIcons.information),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -34,6 +34,7 @@ class _HomeState extends State<Home> {
   Widget build(BuildContext context) {
     final configItem = PageItem(
       titleBuilder: (context) => const Text('Layout'),
+      tooltipMessage: 'Layout',
       pageBuilder: (_) => ListView(
         padding: const EdgeInsets.all(kYaruPagePadding),
         children: [
@@ -103,6 +104,7 @@ class _CompactPage extends StatelessWidget {
       itemBuilder: (context, index, selected) => YaruNavigationRailItem(
         icon: pageItems[index].iconBuilder(context, selected),
         label: pageItems[index].titleBuilder(context),
+        tooltipMessage: pageItems[index].tooltipMessage,
         style: width > 1000
             ? YaruNavigationRailStyle.labelledExtended
             : width > 500

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -104,7 +104,7 @@ class _CompactPage extends StatelessWidget {
       itemBuilder: (context, index, selected) => YaruNavigationRailItem(
         icon: pageItems[index].iconBuilder(context, selected),
         label: pageItems[index].titleBuilder(context),
-        tooltipMessage: pageItems[index].tooltipMessage,
+        tooltip: pageItems[index].tooltipMessage,
         style: width > 1000
             ? YaruNavigationRailStyle.labelledExtended
             : width > 500

--- a/lib/src/layouts/yaru_navigation_rail_item.dart
+++ b/lib/src/layouts/yaru_navigation_rail_item.dart
@@ -14,6 +14,7 @@ enum YaruNavigationRailStyle {
 
 const _kSizeAnimationDuration = Duration(milliseconds: 200);
 const _kSelectedIconAnimationDuration = Duration(milliseconds: 250);
+const _kTooltipWaitDuration = Duration(milliseconds: 500);
 
 class YaruNavigationRailItem extends StatefulWidget {
   const YaruNavigationRailItem({
@@ -21,6 +22,7 @@ class YaruNavigationRailItem extends StatefulWidget {
     this.selected,
     required this.icon,
     required this.label,
+    required this.tooltipMessage,
     this.onTap,
     required this.style,
   });
@@ -28,6 +30,7 @@ class YaruNavigationRailItem extends StatefulWidget {
   final bool? selected;
   final Widget icon;
   final Widget label;
+  final String tooltipMessage;
   final VoidCallback? onTap;
   final YaruNavigationRailStyle style;
 
@@ -49,32 +52,36 @@ class _YaruNavigationRailItemState extends State<YaruNavigationRailItem> {
   @override
   Widget build(BuildContext context) {
     return _buildSizedContainer(
-      Material(
-        child: InkWell(
-          onTap: () {
-            final scope = YaruNavigationRailItemScope.maybeOf(context);
-            scope?.onTap();
-            widget.onTap?.call();
-          },
-          child: Center(
-            child: Padding(
-              padding: EdgeInsets.symmetric(
-                vertical:
-                    widget.style == YaruNavigationRailStyle.labelledExtended
-                        ? 10
-                        : 5,
-                horizontal:
-                    widget.style == YaruNavigationRailStyle.labelledExtended
-                        ? 8
-                        : 5,
+      Tooltip(
+        message: widget.tooltipMessage,
+        waitDuration: _kTooltipWaitDuration,
+        child: Material(
+          child: InkWell(
+            onTap: () {
+              final scope = YaruNavigationRailItemScope.maybeOf(context);
+              scope?.onTap();
+              widget.onTap?.call();
+            },
+            child: Center(
+              child: Padding(
+                padding: EdgeInsets.symmetric(
+                  vertical:
+                      widget.style == YaruNavigationRailStyle.labelledExtended
+                          ? 10
+                          : 5,
+                  horizontal:
+                      widget.style == YaruNavigationRailStyle.labelledExtended
+                          ? 8
+                          : 5,
+                ),
+                child: _buildColumnOrRow([
+                  _buildIcon(context),
+                  if (widget.style != YaruNavigationRailStyle.compact) ...[
+                    _buildGap(),
+                    _buildLabel(context),
+                  ]
+                ]),
               ),
-              child: _buildColumnOrRow([
-                _buildIcon(context),
-                if (widget.style != YaruNavigationRailStyle.compact) ...[
-                  _buildGap(),
-                  _buildLabel(context),
-                ]
-              ]),
             ),
           ),
         ),

--- a/lib/src/layouts/yaru_navigation_rail_item.dart
+++ b/lib/src/layouts/yaru_navigation_rail_item.dart
@@ -22,7 +22,7 @@ class YaruNavigationRailItem extends StatefulWidget {
     this.selected,
     required this.icon,
     required this.label,
-    required this.tooltipMessage,
+    this.tooltip,
     this.onTap,
     required this.style,
   });
@@ -30,7 +30,7 @@ class YaruNavigationRailItem extends StatefulWidget {
   final bool? selected;
   final Widget icon;
   final Widget label;
-  final String tooltipMessage;
+  final String? tooltip;
   final VoidCallback? onTap;
   final YaruNavigationRailStyle style;
 
@@ -52,10 +52,8 @@ class _YaruNavigationRailItemState extends State<YaruNavigationRailItem> {
   @override
   Widget build(BuildContext context) {
     return _buildSizedContainer(
-      Tooltip(
-        message: widget.tooltipMessage,
-        waitDuration: _kTooltipWaitDuration,
-        child: Material(
+      _maybeBuildTooltip(
+        Material(
           child: InkWell(
             onTap: () {
               final scope = YaruNavigationRailItemScope.maybeOf(context);
@@ -124,6 +122,18 @@ class _YaruNavigationRailItemState extends State<YaruNavigationRailItem> {
         ),
       ),
     );
+  }
+
+  Widget _maybeBuildTooltip(Widget child) {
+    if (widget.tooltip != null) {
+      return Tooltip(
+        message: widget.tooltip!,
+        waitDuration: _kTooltipWaitDuration,
+        child: child,
+      );
+    }
+
+    return child;
   }
 
   Widget _buildColumnOrRow(List<Widget> children) {


### PR DESCRIPTION
I let the tooltip message required, because in the configuration without label, it is the only way to understand what the item mean.

![Capture d’écran du 2022-10-13 12-27-16](https://user-images.githubusercontent.com/36476595/195573223-844b2436-5024-4854-85f9-1ed4ed09c084.png)
![Capture d’écran du 2022-10-13 12-27-30](https://user-images.githubusercontent.com/36476595/195573230-bd3653b2-260e-4efe-bba8-8bf9c091f8a9.png)

Related to previous PR: #243