### PR TITLE
Yaru~~Dialog~~TitleBar: add support for leading & trailing widgets

### DIFF
--- a/example/lib/example_page_items.dart
+++ b/example/lib/example_page_items.dart
@@ -121,8 +121,8 @@ final examplePageItems = <PageItem>[
     pageBuilder: (_) => const TilePage(),
   ),
   PageItem(
-    titleBuilder: (context) => const Text('YaruDialogTitle'),
-    tooltipMessage: 'YaruDialogTitle',
+    titleBuilder: (context) => const Text('YaruTitleBar'),
+    tooltipMessage: 'YaruTitleBar',
     iconBuilder: (context, selected) => selected
         ? const Icon(YaruIcons.information_filled)
         : const Icon(YaruIcons.information),

--- a/example/lib/pages/dialog_page.dart
+++ b/example/lib/pages/dialog_page.dart
@@ -39,7 +39,7 @@ class _DialogPageState extends State<DialogPage> {
                           )
                       ],
                       titlePadding: EdgeInsets.zero,
-                      title: YaruDialogTitle(
+                      title: YaruTitleBar(
                         leading: const Center(
                           child: SizedBox.square(
                             dimension: 25,

--- a/example/lib/pages/dialog_page.dart
+++ b/example/lib/pages/dialog_page.dart
@@ -40,22 +40,16 @@ class _DialogPageState extends State<DialogPage> {
                       ],
                       titlePadding: EdgeInsets.zero,
                       title: YaruDialogTitle(
-                        title: Row(
-                          mainAxisSize: MainAxisSize.min,
-                          children: const [
-                            Text('The Title'),
-                            SizedBox(
-                              width: 10,
+                        leading: const Center(
+                          child: SizedBox.square(
+                            dimension: 25,
+                            child: YaruCircularProgressIndicator(
+                              strokeWidth: 3,
                             ),
-                            SizedBox(
-                              height: 25,
-                              child: YaruCircularProgressIndicator(
-                                strokeWidth: 3,
-                              ),
-                            )
-                          ],
+                          ),
                         ),
-                        isCloseable: isCloseable,
+                        title: const Text('The Title'),
+                        trailing: YaruCloseButton(enabled: isCloseable),
                       ),
                       content: SizedBox(
                         height: 100,

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -1,4 +1,5 @@
 const kYaruPagePadding = 20.0;
+const kYaruDialogTitleHeight = 72.0;
 const kYaruDialogTitlePadding = 0.0;
 const kYaruPageWidth = 500.0;
 const kYaruContainerRadius = 8.0;

--- a/lib/src/controls/yaru_title_bar.dart
+++ b/lib/src/controls/yaru_title_bar.dart
@@ -1,14 +1,14 @@
 import 'package:flutter/material.dart';
 
 import '../constants.dart';
-import '../controls/yaru_close_button.dart';
+import 'yaru_close_button.dart';
 
 /// A [Stack] of a [Widget] as [title] with a close button
 /// which pops the top-most route off the navigator
 /// that most tightly encloses the given context.
 ///
-class YaruDialogTitle extends StatelessWidget {
-  const YaruDialogTitle({
+class YaruTitleBar extends StatelessWidget {
+  const YaruTitleBar({
     super.key,
     this.leading,
     this.title,

--- a/lib/src/dialogs/yaru_dialog_title.dart
+++ b/lib/src/dialogs/yaru_dialog_title.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../constants.dart';
+import '../controls/yaru_close_button.dart';
 
 /// A [Stack] of a [Widget] as [title] with a close button
 /// which pops the top-most route off the navigator
@@ -39,14 +40,13 @@ class YaruDialogTitle extends StatelessWidget {
       backgroundColor: Colors.transparent,
       titleTextStyle: Theme.of(context).dialogTheme.titleTextStyle,
       actions: [
-        if (trailing != null)
-          Padding(
-            padding: const EdgeInsets.all(5),
-            child: Align(
-              alignment: Alignment.topRight,
-              child: trailing!,
-            ),
+        Padding(
+          padding: const EdgeInsets.all(5),
+          child: Align(
+            alignment: Alignment.topRight,
+            child: trailing ?? const YaruCloseButton(),
           ),
+        ),
       ],
     );
   }

--- a/lib/src/dialogs/yaru_dialog_title.dart
+++ b/lib/src/dialogs/yaru_dialog_title.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-import '../../yaru_widgets.dart';
+import '../constants.dart';
 
 /// A [Stack] of a [Widget] as [title] with a close button
 /// which pops the top-most route off the navigator
@@ -9,38 +9,43 @@ import '../../yaru_widgets.dart';
 class YaruDialogTitle extends StatelessWidget {
   const YaruDialogTitle({
     super.key,
+    this.leading,
     this.title,
-    required this.isCloseable,
-    this.titleAlignment = Alignment.center,
+    this.trailing,
+    this.centerTitle = true,
   });
 
-  /// The [Widget] used for the title
+  /// The primary title widget.
   final Widget? title;
 
-  /// The alignment of the [title]
-  final AlignmentGeometry titleAlignment;
+  /// A widget to display before the [title] widget.
+  final Widget? leading;
 
-  /// Must provide if this dialog is closeable or not
-  final bool isCloseable;
+  /// A widget to display after the [title] widget.
+  final Widget? trailing;
+
+  /// Whether the title should be centered.
+  final bool? centerTitle;
 
   @override
   Widget build(BuildContext context) {
-    return Stack(
-      alignment: Alignment.topRight,
-      children: [
-        Padding(
-          padding: const EdgeInsets.only(
-            left: kYaruPagePadding + 5, // Avoid title overflow on close button
-            right: kYaruPagePadding, // Avoid title overflow on close button
-            top: kYaruPagePadding,
-            bottom: kYaruPagePadding,
+    return AppBar(
+      elevation: 0,
+      leading: leading,
+      automaticallyImplyLeading: false,
+      title: title,
+      centerTitle: centerTitle,
+      toolbarHeight: kYaruDialogTitleHeight,
+      backgroundColor: Colors.transparent,
+      actions: [
+        if (trailing != null)
+          Padding(
+            padding: const EdgeInsets.all(5),
+            child: Align(
+              alignment: Alignment.topRight,
+              child: trailing!,
+            ),
           ),
-          child: Align(alignment: titleAlignment, child: title),
-        ),
-        Padding(
-          padding: const EdgeInsets.all(5.0),
-          child: YaruCloseButton(enabled: isCloseable),
-        )
       ],
     );
   }

--- a/lib/src/dialogs/yaru_dialog_title.dart
+++ b/lib/src/dialogs/yaru_dialog_title.dart
@@ -37,6 +37,7 @@ class YaruDialogTitle extends StatelessWidget {
       centerTitle: centerTitle,
       toolbarHeight: kYaruDialogTitleHeight,
       backgroundColor: Colors.transparent,
+      titleTextStyle: Theme.of(context).dialogTheme.titleTextStyle,
       actions: [
         if (trailing != null)
           Padding(

--- a/lib/yaru_widgets.dart
+++ b/lib/yaru_widgets.dart
@@ -11,10 +11,9 @@ export 'src/controls/yaru_icon_button.dart';
 export 'src/controls/yaru_option_button.dart';
 export 'src/controls/yaru_progress_indicator.dart';
 export 'src/controls/yaru_radio_button.dart';
+export 'src/controls/yaru_title_bar.dart';
 export 'src/controls/yaru_toggle_button.dart';
 export 'src/controls/yaru_toggle_button_theme.dart';
-// Dialogs
-export 'src/dialogs/yaru_dialog_title.dart';
 // Extensions
 export 'src/extensions/border_radius_extension.dart';
 // Layouts


### PR DESCRIPTION
Implement Yaru~~Dialog~~TitleBar with help of AppBar which already offers these building blocks.

## Pull request checklist

- [x] I added a before/after/light/dark table if the changes I made could change the components look

| |Before|After|
|-|-|-|
|Light| ![image](https://user-images.githubusercontent.com/140617/195582563-ff9afab5-d5aa-4f8b-b58d-f3069f01dadf.png) | ![image](https://user-images.githubusercontent.com/140617/195583113-0b498119-7747-44ed-946c-13beb564dbc1.png) |
|Dark| ![image](https://user-images.githubusercontent.com/140617/195582515-5124bc57-2897-448f-baf7-d92065c0f2ee.png) | ![image](https://user-images.githubusercontent.com/140617/195583171-d5a34fb1-db01-4eae-a5ef-f7e9b6b03941.png) |
