### PR TITLE
LandscapeLayout: fix resize indicator color

### DIFF
--- a/lib/src/layouts/yaru_landscape_layout.dart
+++ b/lib/src/layouts/yaru_landscape_layout.dart
@@ -186,7 +186,7 @@ class _YaruLandscapeLayoutState extends State<YaruLandscapeLayout> {
       child: AnimatedContainer(
         duration: _kLeftPaneResizingRegionAnimationDuration,
         color: _isHovering || _isDragging
-            ? DividerTheme.of(context).color
+            ? Theme.of(context).dividerColor
             : Colors.transparent,
         child: MouseRegion(
           cursor: SystemMouseCursors.resizeColumn,


### PR DESCRIPTION
`DividerTheme.of(context).color` can be null (it is the case here), so I replaced it with `Theme.of(context).dividerColor`.

## Pull request checklist

- [x] I added a before/after/light/dark table if the changes I made could change the components look

<!-- Remove this if your change does not touch components -->
| |Before|After|
|-|-|-|
|Light| ![Capture d’écran du 2022-10-13 17-39-34](https://user-images.githubusercontent.com/36476595/195645604-fd6762fc-e6e3-4ba9-a469-e0ad9a22d11d.png) | ![Capture d’écran du 2022-10-13 17-40-45](https://user-images.githubusercontent.com/36476595/195645615-3d95297a-95a5-46c9-b2c6-6d0374f1e4e5.png) |
|Dark| ![Capture d’écran du 2022-10-13 17-41-04](https://user-images.githubusercontent.com/36476595/195645621-8af2aea0-a5b9-43bd-8d54-9ee40de78013.png) | ![Capture d’écran du 2022-10-13 17-41-21](https://user-images.githubusercontent.com/36476595/195645626-05793f06-22bc-4720-a796-59c4b2b0f81c.png) |