### PR TITLE
Fix use of deprecated members

### DIFF
--- a/example/lib/pages/dialog_page.dart
+++ b/example/lib/pages/dialog_page.dart
@@ -33,7 +33,7 @@ class _DialogPageState extends State<DialogPage> {
                             child: Text(
                               'Evil Force-Close',
                               style: TextStyle(
-                                color: Theme.of(context).errorColor,
+                                color: Theme.of(context).colorScheme.error,
                               ),
                             ),
                           )

--- a/lib/src/controls/yaru_toggle_button.dart
+++ b/lib/src/controls/yaru_toggle_button.dart
@@ -57,14 +57,14 @@ class YaruToggleButton extends StatelessWidget {
                 title: _wrapTextStyle(
                   context,
                   overflow: TextOverflow.ellipsis,
-                  style: Theme.of(context).textTheme.subtitle1!,
+                  style: Theme.of(context).textTheme.titleMedium!,
                   child: title,
                 ),
                 subtitle: subtitle != null
                     ? _wrapTextStyle(
                         context,
                         softWrap: true,
-                        style: Theme.of(context).textTheme.caption!,
+                        style: Theme.of(context).textTheme.bodySmall!,
                         child: subtitle!,
                       )
                     : null,

--- a/lib/src/layouts/yaru_master_tile.dart
+++ b/lib/src/layouts/yaru_master_tile.dart
@@ -86,7 +86,7 @@ class YaruMasterTile extends StatelessWidget {
       child: child,
       maxLines: 1,
       overflow: TextOverflow.ellipsis,
-      style: TextStyle(color: Theme.of(context).textTheme.caption!.color),
+      style: TextStyle(color: Theme.of(context).textTheme.bodySmall!.color),
     );
   }
 


### PR DESCRIPTION
The replacements are available in Flutter 3.3 which is the minimum requirement for anything that depends on yaru.dart.

```
$ flutter --version
Flutter 3.5.0-6.0.pre.37 • channel main • https://github.com/flutter/flutter.git
Framework • revision 08e1729204 (10 hours ago) • 2022-10-13 17:40:07 -0400
Engine • revision 3711bbaeab
Tools • Dart 2.19.0 (build 2.19.0-309.0.dev) • DevTools 2.18.0

$ flutter analyze
Analyzing yaru_widgets.dart...                                          

   info • 'errorColor' is deprecated and shouldn't be used. Use colorScheme.error instead. This feature was deprecated after v3.3.0-0.5.pre. • example/lib/pages/dialog_page.dart:36:58 •
          deprecated_member_use
   info • 'subtitle1' is deprecated and shouldn't be used. Use titleMedium instead. This feature was deprecated after v3.1.0-0.0.pre. • lib/src/controls/yaru_toggle_button.dart:60:54 •
          deprecated_member_use
   info • 'caption' is deprecated and shouldn't be used. Use bodySmall instead. This feature was deprecated after v3.1.0-0.0.pre. • lib/src/controls/yaru_toggle_button.dart:67:60 •
          deprecated_member_use
   info • 'caption' is deprecated and shouldn't be used. Use bodySmall instead. This feature was deprecated after v3.1.0-0.0.pre. • lib/src/layouts/yaru_master_tile.dart:89:59 •
          deprecated_member_use

4 issues found. (ran in 1.2s)

$ dart fix --apply
Computing fixes in yaru_widgets.dart... 18.6s
Applying fixes...                      0.0s

example/lib/pages/dialog_page.dart
  deprecated_member_use • 1 fix

lib/src/controls/yaru_toggle_button.dart
  deprecated_member_use • 2 fixes

lib/src/layouts/yaru_master_tile.dart
  deprecated_member_use • 1 fix

4 fixes made in 3 files.

$ flutter analyze
Analyzing yaru_widgets.dart...                                          
No issues found! (ran in 1.1s)
```