### PR TITLE
Improve YaruBanner

### DIFF
--- a/example/lib/pages/banner_page.dart
+++ b/example/lib/pages/banner_page.dart
@@ -31,7 +31,7 @@ class BannerPage extends StatelessWidget {
             onTap: () => showAboutDialog(context: context),
             surfaceTintColor: i.isEven ? Colors.pink : null,
             watermarkIcon: const Icon(
-              Icons.sunny,
+              Icons.cloud,
               size: 150,
             ),
           )

--- a/example/lib/pages/banner_page.dart
+++ b/example/lib/pages/banner_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
 class BannerPage extends StatelessWidget {
@@ -22,13 +23,17 @@ class BannerPage extends StatelessWidget {
             subtitle: const Text('Description'),
             thirdTitle: const Text('Third line'),
             icon: Icon(
-              Icons.air_sharp,
+              YaruIcons.weather_clear,
               size: 80,
               color: Theme.of(context).primaryColor,
             ),
-            watermark: true,
+            copyIconAsWatermark: true,
             onTap: () => showAboutDialog(context: context),
-            // surfaceTintColor: Colors.pink,
+            surfaceTintColor: i.isEven ? Colors.pink : null,
+            watermarkIcon: const Icon(
+              Icons.sunny,
+              size: 150,
+            ),
           )
       ],
     );

--- a/example/lib/pages/banner_page.dart
+++ b/example/lib/pages/banner_page.dart
@@ -32,7 +32,7 @@ class BannerPage extends StatelessWidget {
             surfaceTintColor: i.isEven ? Colors.pink : null,
             watermarkIcon: const Icon(
               Icons.cloud,
-              size: 150,
+              size: 100,
             ),
           )
       ],

--- a/example/lib/pages/banner_page.dart
+++ b/example/lib/pages/banner_page.dart
@@ -21,7 +21,7 @@ class BannerPage extends StatelessWidget {
           YaruBanner(
             title: Text('YaruBanner $i'),
             subtitle: const Text('Description'),
-            thirdTitle: const Text('Third line'),
+            thirdTitle: i.isEven ? const Text('Third line') : null,
             icon: Icon(
               YaruIcons.weather_clear,
               size: 80,

--- a/example/lib/pages/banner_page.dart
+++ b/example/lib/pages/banner_page.dart
@@ -10,7 +10,7 @@ class BannerPage extends StatelessWidget {
       padding: const EdgeInsets.all(kYaruPagePadding),
       shrinkWrap: true,
       gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
-        mainAxisExtent: 110,
+        mainAxisExtent: 200,
         mainAxisSpacing: 15,
         crossAxisSpacing: 15,
         maxCrossAxisExtent: 550,
@@ -18,10 +18,17 @@ class BannerPage extends StatelessWidget {
       children: [
         for (int i = 0; i < 20; i++)
           YaruBanner(
-            name: Text('YaruBanner $i'),
+            title: Text('YaruBanner $i'),
             subtitle: const Text('Description'),
-            icon: Image.asset('assets/ubuntuhero.jpg'),
+            thirdTitle: const Text('Third line'),
+            icon: Icon(
+              Icons.air_sharp,
+              size: 80,
+              color: Theme.of(context).primaryColor,
+            ),
+            watermark: true,
             onTap: () => showAboutDialog(context: context),
+            // surfaceTintColor: Colors.pink,
           )
       ],
     );

--- a/example/lib/pages/dialog_page.dart
+++ b/example/lib/pages/dialog_page.dart
@@ -55,7 +55,7 @@ class _DialogPageState extends State<DialogPage> {
                         height: 100,
                         child: YaruBanner(
                           surfaceTintColor: Colors.pink,
-                          name: Text(
+                          title: Text(
                             isCloseable
                                 ? 'You can close me'
                                 : 'You cannot close me',

--- a/example/lib/pages/tabbed_page_page.dart
+++ b/example/lib/pages/tabbed_page_page.dart
@@ -31,7 +31,7 @@ class _TabbedPagePageState extends State<TabbedPagePage> {
           children: [
             for (int i = 0; i < 20; i++)
               YaruBanner(
-                name: Text('YaruBanner $i'),
+                title: Text('YaruBanner $i'),
                 subtitle: const Text('Description'),
                 icon: Image.asset('assets/ubuntuhero.jpg'),
                 onTap: () => showAboutDialog(context: context),

--- a/lib/src/pages/yaru_tile.dart
+++ b/lib/src/pages/yaru_tile.dart
@@ -19,6 +19,7 @@ class YaruTile extends StatelessWidget {
     this.trailing,
     this.enabled = true,
     this.padding = const EdgeInsets.all(8.0),
+    this.subTitlePadding = const EdgeInsets.only(top: 4.0),
   });
 
   /// The [Widget] placed at the leading position.
@@ -42,6 +43,8 @@ class YaruTile extends StatelessWidget {
   /// The padding [EdgeInsets] which defaults to `EdgeInsets.all(8.0)`.
   final EdgeInsets padding;
 
+  final EdgeInsets subTitlePadding;
+
   @override
   Widget build(BuildContext context) {
     return DefaultTextStyle(
@@ -63,7 +66,7 @@ class YaruTile extends StatelessWidget {
                   title,
                   if (subtitle != null)
                     Padding(
-                      padding: const EdgeInsets.only(top: 4.0),
+                      padding: subTitlePadding,
                       child: DefaultTextStyle(
                         style: enabled
                             ? Theme.of(context).textTheme.bodySmall!

--- a/lib/src/utilities/yaru_banner.dart
+++ b/lib/src/utilities/yaru_banner.dart
@@ -8,16 +8,15 @@ class YaruBanner extends StatelessWidget {
     this.onTap,
     this.surfaceTintColor,
     this.watermark = false,
-    required this.name,
+    required this.title,
     required this.icon,
-    this.nameTextOverflow,
-    this.summaryTextOverflow,
     this.bannerWidth,
     this.subtitle,
+    this.thirdTitle,
   });
 
   /// The name of the card
-  final Widget name;
+  final Widget title;
 
   /// The subtitle shown in the second line.
   final Widget? subtitle;
@@ -32,13 +31,11 @@ class YaruBanner extends StatelessWidget {
   /// If true the [icon] will be displayed a second time, with small opacity.
   final bool watermark;
 
-  /// The [Widget] used as the trailing icon.
+  /// The [Widget] used as the leading icon.
   final Widget icon;
 
-  final TextOverflow? nameTextOverflow;
-
-  /// Optional [TextOverflow]
-  final TextOverflow? summaryTextOverflow;
+  /// The [Widget] used as the third line.
+  final Widget? thirdTitle;
 
   /// Optional width for the banner - if null it defaults to 370.
   final double? bannerWidth;
@@ -48,27 +45,27 @@ class YaruBanner extends StatelessWidget {
     final borderRadius = BorderRadius.circular(10);
 
     final light = Theme.of(context).brightness == Brightness.light;
+    final defaultCardColor = light
+        ? Theme.of(context).colorScheme.background
+        : Theme.of(context).colorScheme.onSurface.withOpacity(0.01);
     return Material(
       color: Colors.transparent,
       child: InkWell(
         onTap: onTap,
         borderRadius: borderRadius,
         hoverColor: Theme.of(context).colorScheme.onSurface.withOpacity(0.1),
-        child: surfaceTintColor != null
+        child: watermark
             ? Stack(
+                alignment: Alignment.center,
                 children: [
                   _Banner(
-                    subtitleWidget: subtitle,
-                    width: bannerWidth,
-                    borderRadius: borderRadius,
-                    color: surfaceTintColor!,
-                    title: name,
-                    elevation: light ? 4 : 6,
                     icon: icon,
-                    titleTextOverflow:
-                        nameTextOverflow ?? TextOverflow.ellipsis,
-                    subTitleTextOverflow:
-                        summaryTextOverflow ?? TextOverflow.fade,
+                    title: title,
+                    subtitle: subtitle,
+                    thirdTitle: thirdTitle,
+                    borderRadius: borderRadius,
+                    color: surfaceTintColor ?? defaultCardColor,
+                    elevation: light ? 4 : 6,
                     mouseCursor:
                         onTap != null ? SystemMouseCursors.click : null,
                   ),
@@ -89,18 +86,13 @@ class YaruBanner extends StatelessWidget {
                 ],
               )
             : _Banner(
-                subtitleWidget: subtitle,
-                width: bannerWidth,
-                borderRadius: borderRadius,
-                color: light
-                    ? Theme.of(context).colorScheme.background
-                    : Theme.of(context).colorScheme.onSurface.withOpacity(0.01),
-                elevation: light ? 2 : 1,
                 icon: icon,
-                title: name,
-                titleTextOverflow: nameTextOverflow ?? TextOverflow.ellipsis,
-                subTitleTextOverflow:
-                    summaryTextOverflow ?? TextOverflow.ellipsis,
+                title: title,
+                subtitle: subtitle,
+                thirdTitle: thirdTitle,
+                borderRadius: borderRadius,
+                color: defaultCardColor,
+                elevation: light ? 2 : 1,
                 mouseCursor: onTap != null ? SystemMouseCursors.click : null,
               ),
       ),
@@ -115,11 +107,9 @@ class _Banner extends StatelessWidget {
     required this.elevation,
     required this.icon,
     required this.borderRadius,
-    required this.subTitleTextOverflow,
     this.mouseCursor,
-    required this.titleTextOverflow,
-    this.width,
-    this.subtitleWidget,
+    this.subtitle,
+    this.thirdTitle,
   });
 
   final Color color;
@@ -127,14 +117,22 @@ class _Banner extends StatelessWidget {
   final double elevation;
   final Widget icon;
   final BorderRadius borderRadius;
-  final TextOverflow subTitleTextOverflow;
-  final TextOverflow titleTextOverflow;
   final MouseCursor? mouseCursor;
-  final double? width;
-  final Widget? subtitleWidget;
+  final Widget? subtitle;
+  final Widget? thirdTitle;
 
   @override
   Widget build(BuildContext context) {
+    final sub = Column(
+      mainAxisAlignment: MainAxisAlignment.start,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (subtitle != null) subtitle!,
+        if (thirdTitle != null) thirdTitle!,
+      ],
+    );
+
     return Card(
       shadowColor: Colors.transparent,
       surfaceTintColor: color,
@@ -144,33 +142,22 @@ class _Banner extends StatelessWidget {
             .inner(const EdgeInsets.all(4.0)), // 4 is the default margin
         side: BorderSide(color: Theme.of(context).dividerColor, width: 1),
       ),
-      child: Align(
-        alignment: Alignment.centerLeft,
-        child: SizedBox(
-          width: width ?? 370,
-          child: ListTile(
-            mouseCursor: mouseCursor,
-            subtitle: subtitleWidget != null
-                ? DefaultTextStyle(
-                    style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                          color: Theme.of(context).textTheme.bodySmall!.color,
-                          overflow: subTitleTextOverflow,
-                        ),
-                    child: subtitleWidget!,
-                  )
-                : null,
-            title: DefaultTextStyle(
-              child: title,
-              style: Theme.of(context)
-                  .textTheme
-                  .bodyLarge!
-                  .copyWith(fontSize: 20, overflow: titleTextOverflow),
-            ),
-            leading: SizedBox(
-              width: 60,
-              child: icon,
-            ),
+      child: ConstrainedBox(
+        constraints: const BoxConstraints.expand(),
+        child: YaruTile(
+          subtitle: DefaultTextStyle(
+            style: Theme.of(context).textTheme.bodyMedium!.copyWith(
+                  color: Theme.of(context).textTheme.bodySmall!.color,
+                ),
+            child: sub,
           ),
+          title: DefaultTextStyle(
+            child: title,
+            style: Theme.of(context).textTheme.bodyLarge!.copyWith(
+                  fontSize: 20,
+                ),
+          ),
+          leading: icon,
         ),
       ),
     );

--- a/lib/src/utilities/yaru_banner.dart
+++ b/lib/src/utilities/yaru_banner.dart
@@ -7,12 +7,13 @@ class YaruBanner extends StatelessWidget {
     super.key,
     this.onTap,
     this.surfaceTintColor,
-    this.watermark = false,
+    this.copyIconAsWatermark = false,
     required this.title,
     required this.icon,
     this.bannerWidth,
     this.subtitle,
     this.thirdTitle,
+    this.watermarkIcon,
   });
 
   /// The name of the card
@@ -29,10 +30,13 @@ class YaruBanner extends StatelessWidget {
   final Color? surfaceTintColor;
 
   /// If true the [icon] will be displayed a second time, with small opacity.
-  final bool watermark;
+  final bool copyIconAsWatermark;
 
   /// The [Widget] used as the leading icon.
   final Widget icon;
+
+  /// Optional [Widget] placed as the watermark
+  final Widget? watermarkIcon;
 
   /// The [Widget] used as the third line.
   final Widget? thirdTitle;
@@ -54,7 +58,7 @@ class YaruBanner extends StatelessWidget {
         onTap: onTap,
         borderRadius: borderRadius,
         hoverColor: Theme.of(context).colorScheme.onSurface.withOpacity(0.1),
-        child: watermark
+        child: copyIconAsWatermark
             ? Stack(
                 alignment: Alignment.center,
                 children: [
@@ -69,17 +73,14 @@ class YaruBanner extends StatelessWidget {
                     mouseCursor:
                         onTap != null ? SystemMouseCursors.click : null,
                   ),
-                  if (watermark == true)
+                  if (copyIconAsWatermark == true)
                     Padding(
                       padding: const EdgeInsets.only(right: 20),
                       child: Align(
                         alignment: Alignment.centerRight,
                         child: Opacity(
                           opacity: 0.1,
-                          child: SizedBox(
-                            height: 130,
-                            child: icon,
-                          ),
+                          child: watermarkIcon != null ? watermarkIcon! : icon,
                         ),
                       ),
                     ),

--- a/lib/src/utilities/yaru_banner.dart
+++ b/lib/src/utilities/yaru_banner.dart
@@ -146,6 +146,7 @@ class _Banner extends StatelessWidget {
       child: ConstrainedBox(
         constraints: const BoxConstraints.expand(),
         child: YaruTile(
+          subTitlePadding: EdgeInsets.zero,
           subtitle: DefaultTextStyle(
             style: Theme.of(context).textTheme.bodyMedium!.copyWith(
                   color: Theme.of(context).textTheme.bodySmall!.color,


### PR DESCRIPTION
YauBanner was yet one more static hodgepodge imported from a different project

Now it should be a bit more flexible.

Also it is now possible to add a third line (potentially important for the software app)

The watermark can now also be replaced by a different Widget if wanted.

I changed the example to show what is possible with the banner.

Fixes #306

## Pull request checklist

- [x] I added a before/after/light/dark table if the changes I made could change the components look

<!-- Remove this if your change does not touch components -->
| |Before|After|
|-|-|-|
|Light|![grafik](https://user-images.githubusercontent.com/15329494/196405155-6a3b05c1-f47b-4226-9558-cf7657d05d6e.png)|![grafik](https://user-images.githubusercontent.com/15329494/196410327-91924265-244a-4467-8182-191395cc03a7.png)|
|Dark|![grafik](https://user-images.githubusercontent.com/15329494/196405250-7e86312a-d4e5-4745-9924-0c40f7a0e458.png)|![grafik](https://user-images.githubusercontent.com/15329494/196410218-832eb72f-dddc-4d81-868f-9f7fe1f0b5ea.png)|

Smaller banners are still possible ofc:
![grafik](https://user-images.githubusercontent.com/15329494/196410430-2db03510-2bfc-427f-82b1-d4f943ab96a0.png)

