### PR TITLE
YaruPopupMenuButton: use builder and improve

### DIFF
--- a/example/lib/pages/popup_page.dart
+++ b/example/lib/pages/popup_page.dart
@@ -24,16 +24,18 @@ class _PopupPageState extends State<PopupPage> {
               });
             },
             child: Text(myEnum.name),
-            items: [
-              for (final value in MyEnum.values)
-                PopupMenuItem(
-                  value: value,
-                  child: Text(
-                    value.name,
-                  ),
-                )
-            ],
-          )
+            itemBuilder: (context) {
+              return [
+                for (final value in MyEnum.values)
+                  PopupMenuItem(
+                    value: value,
+                    child: Text(
+                      value.name,
+                    ),
+                  )
+              ];
+            },
+          ),
         ],
       ),
     );

--- a/lib/src/controls/yaru_popup_menu_button.dart
+++ b/lib/src/controls/yaru_popup_menu_button.dart
@@ -15,6 +15,7 @@ class YaruPopupMenuButton<T> extends StatelessWidget {
     this.tooltip,
     this.position = PopupMenuPosition.under,
     this.padding = const EdgeInsets.symmetric(horizontal: 5),
+    this.childPadding = const EdgeInsets.symmetric(horizontal: 5),
     this.enabled = true,
   });
 
@@ -26,6 +27,7 @@ class YaruPopupMenuButton<T> extends StatelessWidget {
   final PopupMenuPosition position;
   final List<PopupMenuEntry<T>> Function(BuildContext) itemBuilder;
   final EdgeInsets padding;
+  final EdgeInsets childPadding;
   final bool enabled;
 
   @override
@@ -46,6 +48,7 @@ class YaruPopupMenuButton<T> extends StatelessWidget {
           child: _YaruPopupDecoration(
             child: child,
             padding: padding,
+            childPadding: childPadding,
           ),
         ),
       ),
@@ -59,10 +62,12 @@ class _YaruPopupDecoration extends StatelessWidget {
     super.key,
     required this.child,
     required this.padding,
+    required this.childPadding,
   });
 
   final Widget child;
   final EdgeInsets padding;
+  final EdgeInsets childPadding;
 
   @override
   Widget build(BuildContext context) {
@@ -72,7 +77,7 @@ class _YaruPopupDecoration extends StatelessWidget {
         fontWeight: FontWeight.w500,
       ),
       child: Container(
-        padding: padding,
+        padding: childPadding,
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(kYaruButtonRadius),
           border: Border.all(color: Theme.of(context).dividerColor),

--- a/lib/src/controls/yaru_popup_menu_button.dart
+++ b/lib/src/controls/yaru_popup_menu_button.dart
@@ -9,45 +9,39 @@ class YaruPopupMenuButton<T> extends StatelessWidget {
     super.key,
     required this.initialValue,
     required this.child,
-    required this.items,
+    required this.itemBuilder,
     this.onSelected,
     this.onCanceled,
     this.tooltip,
     this.position = PopupMenuPosition.under,
+    this.childPadding = const EdgeInsets.symmetric(horizontal: 5),
   });
 
   final T initialValue;
   final Widget child;
-  final List<PopupMenuItem<T>> items;
   final Function(T)? onSelected;
   final Function()? onCanceled;
   final String? tooltip;
   final PopupMenuPosition position;
+  final List<PopupMenuEntry<T>> Function(BuildContext) itemBuilder;
+  final EdgeInsets childPadding;
 
   @override
   Widget build(BuildContext context) {
-    return DefaultTextStyle(
-      style: Theme.of(context).textTheme.bodyMedium ??
-          TextStyle(
-            fontSize: 20,
-            color: Theme.of(context).colorScheme.onSurface,
-          ),
-      child: ClipRRect(
-        borderRadius: BorderRadius.circular(kYaruButtonRadius),
-        child: Material(
-          color: Colors.transparent,
-          child: PopupMenuButton(
-            padding: EdgeInsets.zero,
-            initialValue: initialValue,
-            onSelected: onSelected,
-            onCanceled: onCanceled,
-            tooltip: tooltip,
-            itemBuilder: (context) {
-              return items;
-            },
-            child: YaruPopupDecoration(
-              child: child,
-            ),
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(kYaruButtonRadius),
+      child: Material(
+        color: Colors.transparent,
+        child: PopupMenuButton(
+          padding: EdgeInsets.zero,
+          initialValue: initialValue,
+          onSelected: onSelected,
+          onCanceled: onCanceled,
+          tooltip: tooltip,
+          itemBuilder: itemBuilder,
+          child: _YaruPopupDecoration(
+            child: child,
+            childPadding: childPadding,
           ),
         ),
       ),
@@ -55,11 +49,12 @@ class YaruPopupMenuButton<T> extends StatelessWidget {
   }
 }
 
-class YaruPopupDecoration extends StatelessWidget {
-  const YaruPopupDecoration({
+class _YaruPopupDecoration extends StatelessWidget {
+  const _YaruPopupDecoration({
+    // ignore: unused_element
     super.key,
     required this.child,
-    this.childPadding = const EdgeInsets.symmetric(horizontal: 5),
+    required this.childPadding,
   });
 
   final Widget child;
@@ -67,28 +62,34 @@ class YaruPopupDecoration extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(kYaruButtonRadius),
-        border: Border.all(color: Theme.of(context).dividerColor),
+    return DefaultTextStyle(
+      style: TextStyle(
+        color: Theme.of(context).colorScheme.onSurface,
+        fontWeight: FontWeight.w500,
       ),
-      child: Padding(
-        padding: childPadding,
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Padding(
-              padding: childPadding,
-              child: child,
-            ),
-            const SizedBox(
-              height: 40,
-              child: Icon(
-                YaruIcons.pan_down,
-                size: 20,
+      child: Container(
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(kYaruButtonRadius),
+          border: Border.all(color: Theme.of(context).dividerColor),
+        ),
+        child: Padding(
+          padding: childPadding,
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Padding(
+                padding: childPadding,
+                child: child,
               ),
-            ),
-          ],
+              const SizedBox(
+                height: 40,
+                child: Icon(
+                  YaruIcons.pan_down,
+                  size: 20,
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/src/controls/yaru_popup_menu_button.dart
+++ b/lib/src/controls/yaru_popup_menu_button.dart
@@ -14,7 +14,8 @@ class YaruPopupMenuButton<T> extends StatelessWidget {
     this.onCanceled,
     this.tooltip,
     this.position = PopupMenuPosition.under,
-    this.childPadding = const EdgeInsets.symmetric(horizontal: 5),
+    this.padding = const EdgeInsets.symmetric(horizontal: 5),
+    this.enabled = true,
   });
 
   final T initialValue;
@@ -24,7 +25,8 @@ class YaruPopupMenuButton<T> extends StatelessWidget {
   final String? tooltip;
   final PopupMenuPosition position;
   final List<PopupMenuEntry<T>> Function(BuildContext) itemBuilder;
-  final EdgeInsets childPadding;
+  final EdgeInsets padding;
+  final bool enabled;
 
   @override
   Widget build(BuildContext context) {
@@ -33,6 +35,8 @@ class YaruPopupMenuButton<T> extends StatelessWidget {
       child: Material(
         color: Colors.transparent,
         child: PopupMenuButton(
+          enabled: enabled,
+          position: position,
           padding: EdgeInsets.zero,
           initialValue: initialValue,
           onSelected: onSelected,
@@ -41,7 +45,7 @@ class YaruPopupMenuButton<T> extends StatelessWidget {
           itemBuilder: itemBuilder,
           child: _YaruPopupDecoration(
             child: child,
-            childPadding: childPadding,
+            padding: padding,
           ),
         ),
       ),
@@ -54,11 +58,11 @@ class _YaruPopupDecoration extends StatelessWidget {
     // ignore: unused_element
     super.key,
     required this.child,
-    required this.childPadding,
+    required this.padding,
   });
 
   final Widget child;
-  final EdgeInsets childPadding;
+  final EdgeInsets padding;
 
   @override
   Widget build(BuildContext context) {
@@ -68,28 +72,26 @@ class _YaruPopupDecoration extends StatelessWidget {
         fontWeight: FontWeight.w500,
       ),
       child: Container(
+        padding: padding,
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(kYaruButtonRadius),
           border: Border.all(color: Theme.of(context).dividerColor),
         ),
-        child: Padding(
-          padding: childPadding,
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Padding(
-                padding: childPadding,
-                child: child,
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Padding(
+              padding: padding,
+              child: child,
+            ),
+            const SizedBox(
+              height: 40,
+              child: Icon(
+                YaruIcons.pan_down,
+                size: 20,
               ),
-              const SizedBox(
-                height: 40,
-                child: Icon(
-                  YaruIcons.pan_down,
-                  size: 20,
-                ),
-              ),
-            ],
-          ),
+            ),
+          ],
         ),
       ),
     );


### PR DESCRIPTION
## Pull request checklist

- [x] I added a before/after/light/dark table if the changes I made could change the components look

<!-- Remove this if your change does not touch components -->
| |Before|After|
|-|-|-|
|Light|![image](https://user-images.githubusercontent.com/15329494/197112166-ba86e9b8-676a-4164-a848-d2caaf5f1d80.png)|![image](https://user-images.githubusercontent.com/15329494/197112083-8346e620-1ef0-4c3e-bada-1022bdd88838.png)|
|Dark|![image](https://user-images.githubusercontent.com/15329494/197112251-10330986-95b7-40b8-8b36-19c3c1fa60b2.png) |![image](https://user-images.githubusercontent.com/15329494/197112029-15af9fd0-1dfb-4c4a-8f72-549605db34bb.png)|

@jpnurmi as requested the decoration is private and the builder is now the parameter instead of the item list

I also tried to get closer to the outlined button.