### PR TITLE
Upgrade yaru.dart to v0.4.3

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
   handy_window: ^0.1.2
   provider: ^6.0.2
-  yaru: ^0.4.1
+  yaru: ^0.4.3
   yaru_icons: ^0.2.1
   yaru_widgets:
     path: ../

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  yaru: ^0.4.2
+  yaru: ^0.4.3
   yaru_icons: ^0.2.4
 
 dev_dependencies:


### PR DESCRIPTION
^0.4.x automatically includes 0.4.3 but forcing 0.4.3+ ensures that YaruMasterDetailPage golden tests (#327) will pass for everyone locally.