### PR TITLE
YaruCarousel: allow creating without controller

### DIFF
--- a/example/lib/pages/carousel_page.dart
+++ b/example/lib/pages/carousel_page.dart
@@ -11,16 +11,7 @@ class CarouselPage extends StatefulWidget {
 
 class _CarouselPageState extends State<CarouselPage> {
   int length = 3;
-  late final YaruCarouselController _autoScrollController;
-
-  @override
-  void initState() {
-    super.initState();
-    _autoScrollController = YaruCarouselController(
-      autoScroll: true,
-      pagesLength: length,
-    );
-  }
+  final _autoScrollController = YaruCarouselController(autoScroll: true);
 
   @override
   void dispose() {

--- a/example/lib/pages/carousel_page.dart
+++ b/example/lib/pages/carousel_page.dart
@@ -11,6 +11,22 @@ class CarouselPage extends StatefulWidget {
 
 class _CarouselPageState extends State<CarouselPage> {
   int length = 3;
+  late final YaruCarouselController _autoScrollController;
+
+  @override
+  void initState() {
+    super.initState();
+    _autoScrollController = YaruCarouselController(
+      autoScroll: true,
+      pagesLength: length,
+    );
+  }
+
+  @override
+  void dispose() {
+    _autoScrollController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -33,10 +49,7 @@ class _CarouselPageState extends State<CarouselPage> {
           width: 700,
           children: [
             YaruCarousel(
-              controller: YaruCarouselController(
-                autoScroll: true,
-                pagesLength: _getCarouselChildren().length,
-              ),
+              controller: _autoScrollController,
               children: _getCarouselChildren(),
               height: 400,
             ),

--- a/example/lib/pages/carousel_page.dart
+++ b/example/lib/pages/carousel_page.dart
@@ -22,9 +22,6 @@ class _CarouselPageState extends State<CarouselPage> {
           width: 700,
           children: [
             YaruCarousel(
-              controller: YaruCarouselController(
-                pagesLength: _getCarouselChildren().length,
-              ),
               children: _getCarouselChildren(),
               height: 400,
               navigationControls: true,

--- a/lib/src/utilities/yaru_carousel.dart
+++ b/lib/src/utilities/yaru_carousel.dart
@@ -67,11 +67,14 @@ class _YaruCarouselState extends State<YaruCarousel> {
     super.didUpdateWidget(oldWidget);
 
     if (widget.controller != oldWidget.controller) {
+      final oldInitialPage = _controller.initialPage;
       if (oldWidget.controller == null) {
         _controller.dispose();
       }
       _controller = widget.controller ?? YaruCarouselController();
-      _page = _controller.initialPage;
+      if (oldInitialPage != _controller.initialPage) {
+        _page = _controller.initialPage;
+      }
     }
 
     if (_page > widget.children.length - 1) {

--- a/lib/src/utilities/yaru_carousel.dart
+++ b/lib/src/utilities/yaru_carousel.dart
@@ -58,8 +58,7 @@ class _YaruCarouselState extends State<YaruCarousel> {
   @override
   void initState() {
     super.initState();
-    _controller = widget.controller ??
-        YaruCarouselController(pagesLength: widget.children.length);
+    _controller = widget.controller ?? YaruCarouselController();
     _page = _controller.initialPage;
   }
 
@@ -71,8 +70,7 @@ class _YaruCarouselState extends State<YaruCarousel> {
       if (oldWidget.controller == null) {
         _controller.dispose();
       }
-      _controller = widget.controller ??
-          YaruCarouselController(pagesLength: widget.children.length);
+      _controller = widget.controller ?? YaruCarouselController();
       _page = _controller.initialPage;
     }
 
@@ -257,7 +255,6 @@ class _YaruCarouselState extends State<YaruCarousel> {
 class YaruCarouselController extends PageController {
   YaruCarouselController({
     super.initialPage,
-    required this.pagesLength,
     super.keepPage,
     super.viewportFraction = 0.8,
     this.scrollAnimationDuration = const Duration(milliseconds: 500),
@@ -265,8 +262,6 @@ class YaruCarouselController extends PageController {
     this.autoScroll = false,
     this.autoScrollDuration = const Duration(seconds: 3),
   });
-
-  final int pagesLength;
 
   final Duration scrollAnimationDuration;
 
@@ -336,6 +331,9 @@ class YaruCarouselController extends PageController {
   void startTimer() {
     if (autoScroll) {
       _timer = Timer(autoScrollDuration, () {
+        final carousel = position.context.notificationContext
+            ?.findAncestorWidgetOfExactType<YaruCarousel>();
+        final pagesLength = carousel?.children.length ?? 0;
         animateToPage(page!.round() + 1 >= pagesLength ? 0 : page!.round() + 1);
       });
     }


### PR DESCRIPTION
For simpler use cases where the user doesn't need to control the carousel, it's more convenient if `YaruCarousel` internally creates its own controller on demand. It's important to keep in mind that `YaruCarousel` does not own `widget.controller` - only the internal controller that was created if the user did not supply any (i.e. `widget.controller` is null).

## Pull request checklist

- [x] Either this PR does not introduce visual changes, or
- [ ] I run `flutter test --update-goldens` and committed the changes if there were any, or
- [ ] I added before/after/light/dark screenshots if the visual changes I made were not covered by golden tests.

<!--
| |Before|After|
|-|-|-|
|Light| | |
|Dark| | |

-->
