### PR TITLE
Example: update nav icons

### DIFF
--- a/example/lib/example_page_items.dart
+++ b/example/lib/example_page_items.dart
@@ -124,11 +124,9 @@ final examplePageItems = <PageItem>[
     titleBuilder: (context) => const Text('YaruSwitchButton'),
     tooltipMessage: 'YaruSwitchButton',
     pageBuilder: (context) => const SwitchButtonPage(),
-    // TODO: YaruIcons.switch/toggle?
-
     iconBuilder: (context, selected) => selected
         ? const Icon(YaruIcons.switch_button_checked_filled)
-        : const Icon(YaruIcons.switch_button_checked),
+        : const Icon(YaruIcons.switch_button),
   ),
   PageItem(
     titleBuilder: (context) => const Text('YaruTabbedPage'),

--- a/example/lib/example_page_items.dart
+++ b/example/lib/example_page_items.dart
@@ -51,8 +51,9 @@ final examplePageItems = <PageItem>[
     titleBuilder: (context) => const Text('YaruCheckButton'),
     tooltipMessage: 'YaruCheckButton',
     pageBuilder: (context) => const CheckButtonPage(),
-    iconBuilder: (context, selected) =>
-        const Icon(YaruIcons.checkbox_button_checked),
+    iconBuilder: (context, selected) => selected
+        ? const Icon(YaruIcons.checkbox_button_checked_filled)
+        : const Icon(YaruIcons.checkbox_button_checked),
   ),
   PageItem(
     titleBuilder: (context) => const Text('YaruColorDisk'),
@@ -81,7 +82,9 @@ final examplePageItems = <PageItem>[
   PageItem(
     titleBuilder: (context) => const Text('YaruOptionButton'),
     tooltipMessage: 'YaruOptionButton',
-    iconBuilder: (context, selected) => const Icon(YaruIcons.settings),
+    iconBuilder: (context, selected) => selected
+        ? const Icon(YaruIcons.settings_filled)
+        : const Icon(YaruIcons.settings),
     pageBuilder: (_) => const OptionButtonPage(),
   ),
   PageItem(
@@ -101,8 +104,9 @@ final examplePageItems = <PageItem>[
     titleBuilder: (context) => const Text('YaruRadioButton'),
     tooltipMessage: 'YaruRadioButton',
     pageBuilder: (context) => const RadioButtonPage(),
-    iconBuilder: (context, selected) =>
-        const Icon(YaruIcons.radio_button_checked),
+    iconBuilder: (context, selected) => selected
+        ? const Icon(YaruIcons.radio_button_checked_filled)
+        : const Icon(YaruIcons.radio_button_checked),
   ),
   PageItem(
     titleBuilder: (context) => const Text('YaruSection'),
@@ -121,21 +125,10 @@ final examplePageItems = <PageItem>[
     tooltipMessage: 'YaruSwitchButton',
     pageBuilder: (context) => const SwitchButtonPage(),
     // TODO: YaruIcons.switch/toggle?
-    iconBuilder: (context, selected) => Container(
-      width: 24,
-      height: 12,
-      decoration: BoxDecoration(
-        color: IconTheme.of(context).color,
-        borderRadius: BorderRadius.circular(6),
-      ),
-      child: Container(
-        margin: const EdgeInsets.fromLTRB(14, 2, 2, 2),
-        decoration: BoxDecoration(
-          color: Theme.of(context).colorScheme.surface,
-          borderRadius: BorderRadius.circular(4),
-        ),
-      ),
-    ),
+
+    iconBuilder: (context, selected) => selected
+        ? const Icon(YaruIcons.switch_button_checked_filled)
+        : const Icon(YaruIcons.switch_button_checked),
   ),
   PageItem(
     titleBuilder: (context) => const Text('YaruTabbedPage'),

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   handy_window: ^0.1.2
   provider: ^6.0.2
   yaru: ^0.4.3
-  yaru_icons: ^0.2.1
+  yaru_icons: ^0.2.6
   yaru_widgets:
     path: ../
 


### PR DESCRIPTION
- update to yaru_icons 0.2.6
- use new switch icon
- use filled icons when available (checkbox and radio)

![Capture d’écran du 2022-10-25 23-03-46](https://user-images.githubusercontent.com/36476595/197881834-e7ae0dc8-25b4-47e6-9de0-d4c30c8d0f49.png)
![Capture d’écran du 2022-10-25 23-03-40](https://user-images.githubusercontent.com/36476595/197881838-1bdcf8e0-7752-4a57-8e3b-4d3b0edad11a.png)

