### PR TITLE
Showcase all YaruValues of the enum instead of the hard-coded list.

### DIFF
--- a/example/lib/pages/color_disk_page.dart
+++ b/example/lib/pages/color_disk_page.dart
@@ -23,7 +23,7 @@ class _ColorDiskPageState extends State<ColorDiskPage> {
         crossAxisAlignment: CrossAxisAlignment.start,
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
-          for (var theme in themeList)
+          for (var theme in YaruVariant.values)
             YaruColorDisk(
               onPressed: () {
                 lightTheme.value = theme.theme;
@@ -37,16 +37,3 @@ class _ColorDiskPageState extends State<ColorDiskPage> {
     );
   }
 }
-
-const List<YaruVariant> themeList = [
-  YaruVariant.orange,
-  YaruVariant.sage,
-  YaruVariant.bark,
-  YaruVariant.olive,
-  YaruVariant.viridian,
-  YaruVariant.prussianGreen,
-  YaruVariant.blue,
-  YaruVariant.purple,
-  YaruVariant.magenta,
-  YaruVariant.red,
-];


### PR DESCRIPTION
## Pull request checklist

- [ ] Either this PR does not introduce visual changes, or
- [ ] I run `flutter test --update-goldens` and committed the changes if there were any, or
- [X] I added before/after/light/dark screenshots if the visual changes I made were not covered by golden tests.

Before:
![image](https://user-images.githubusercontent.com/52143624/198298205-19a3632e-743f-421f-a2bc-093b2e93ff96.png)

After:
![image](https://user-images.githubusercontent.com/52143624/198298107-489759d0-bedb-40aa-9c39-1e563ab128dc.png)