### PR TITLE
Decrease YaruTitleBar height

### DIFF
--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -2,7 +2,7 @@
 const kYaruPagePadding = 20.0;
 
 /// The default height of [YaruTitleBar].
-const kYaruTitleBarHeight = 72.0;
+const kYaruTitleBarHeight = 50.0;
 
 /// The default border radius for Yaru-style containers.
 const kYaruContainerRadius = 8.0;

--- a/lib/src/controls/yaru_close_button.dart
+++ b/lib/src/controls/yaru_close_button.dart
@@ -3,6 +3,8 @@ import 'package:yaru_icons/yaru_icons.dart';
 
 import 'yaru_icon_button.dart';
 
+const _kCloseButtonSize = 32.0;
+
 class YaruCloseButton extends StatelessWidget {
   const YaruCloseButton({
     super.key,
@@ -15,12 +17,14 @@ class YaruCloseButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return YaruIconButton(
-      style: IconButton.styleFrom(
-        fixedSize: const Size.square(34),
+    return Align(
+      alignment: Alignment.center,
+      child: YaruIconButton(
+        padding: EdgeInsets.zero,
+        onPressed: enabled ? onPressed ?? Navigator.of(context).maybePop : null,
+        icon: const Icon(YaruIcons.window_close),
+        iconSize: _kCloseButtonSize,
       ),
-      onPressed: enabled ? onPressed ?? Navigator.of(context).maybePop : null,
-      icon: const Icon(YaruIcons.window_close),
     );
   }
 }


### PR DESCRIPTION
Fixes #356

## Pull request checklist

- [x] I added before/after/light/dark screenshots if the visual changes I made were not covered by golden tests.

| |Before|After|
|-|-|-|
|Light| ![Capture d’écran du 2022-11-02 19-20-41](https://user-images.githubusercontent.com/36476595/199571203-3ac3b08c-33dc-4243-9efc-040b94756192.png) | ![Capture d’écran du 2022-11-02 19-21-25](https://user-images.githubusercontent.com/36476595/199571186-8fe2fee7-d5c7-4388-9f79-9598f652973e.png) |
|Dark| ![Capture d’écran du 2022-11-02 19-20-54](https://user-images.githubusercontent.com/36476595/199571196-8f403db5-8cb5-43f6-81eb-3f56eb0385de.png) | ![Capture d’écran du 2022-11-02 19-21-15](https://user-images.githubusercontent.com/36476595/199571194-fb7b567c-b40a-4d83-944f-0f1101e46efa.png) |

**Note:** Gtk headerbar is 48px height, but I needed to add 2 additional px cause of the titlebar bottom border to have the feeling it has the same height as Gtk headerbar.