### PR TITLE
Master detail controller

### DIFF
--- a/lib/src/layouts/yaru_landscape_layout.dart
+++ b/lib/src/layouts/yaru_landscape_layout.dart
@@ -19,6 +19,7 @@ class YaruLandscapeLayout extends StatefulWidget {
     required this.pageMinWidth,
     this.onLeftPaneWidthChange,
     this.appBar,
+    this.controller,
   });
 
   /// The total number of pages.
@@ -55,6 +56,9 @@ class YaruLandscapeLayout extends StatefulWidget {
   /// If provided, a second [AppBar] will be created right to it.
   final PreferredSizeWidget? appBar;
 
+  /// An optional controller that can be used to navigate to a specific index.
+  final ValueNotifier<int>? controller;
+
   @override
   State<YaruLandscapeLayout> createState() => _YaruLandscapeLayoutState();
 }
@@ -77,6 +81,17 @@ class _YaruLandscapeLayoutState extends State<YaruLandscapeLayout> {
     super.initState();
     _selectedIndex = widget.selectedIndex;
     _leftPaneWidth = widget.leftPaneWidth;
+    widget.controller?.addListener(_controllerCallback);
+  }
+
+  @override
+  void dispose() {
+    widget.controller?.removeListener(_controllerCallback);
+    super.dispose();
+  }
+
+  void _controllerCallback() {
+    _onTap(widget.controller!.value);
   }
 
   void _onTap(int index) {

--- a/lib/src/layouts/yaru_master_detail_page.dart
+++ b/lib/src/layouts/yaru_master_detail_page.dart
@@ -56,6 +56,7 @@ class YaruMasterDetailPage extends StatefulWidget {
     this.appBar,
     this.initialIndex,
     this.onSelected,
+    this.controller,
   });
 
   /// The total number of pages.
@@ -95,6 +96,9 @@ class YaruMasterDetailPage extends StatefulWidget {
 
   /// Called when the user selects a page.
   final ValueChanged<int?>? onSelected;
+
+  /// An optional controller that can be used to navigate to a specific index.
+  final ValueNotifier<int>? controller;
 
   @override
   _YaruMasterDetailPageState createState() => _YaruMasterDetailPageState();
@@ -141,6 +145,7 @@ class _YaruMasterDetailPageState extends State<YaruMasterDetailPage> {
             pageBuilder: widget.pageBuilder,
             onSelected: _setIndex,
             appBar: widget.appBar,
+            controller: widget.controller,
           );
         } else {
           return YaruLandscapeLayout(
@@ -155,6 +160,7 @@ class _YaruMasterDetailPageState extends State<YaruMasterDetailPage> {
             pageMinWidth: widget.pageMinWidth,
             onLeftPaneWidthChange: (panWidth) => _leftPaneWidth = panWidth,
             appBar: widget.appBar,
+            controller: widget.controller,
           );
         }
       },

--- a/lib/src/layouts/yaru_portrait_layout.dart
+++ b/lib/src/layouts/yaru_portrait_layout.dart
@@ -13,6 +13,7 @@ class YaruPortraitLayout extends StatefulWidget {
     required this.pageBuilder,
     required this.onSelected,
     this.appBar,
+    this.controller,
   });
 
   final int length;
@@ -22,6 +23,9 @@ class YaruPortraitLayout extends StatefulWidget {
   final ValueChanged<int> onSelected;
 
   final PreferredSizeWidget? appBar;
+
+  /// An optional controller that can be used to navigate to a specific index.
+  final ValueNotifier<int>? controller;
 
   @override
   _YaruPortraitLayoutState createState() => _YaruPortraitLayoutState();
@@ -36,7 +40,19 @@ class _YaruPortraitLayoutState extends State<YaruPortraitLayout> {
   @override
   void initState() {
     _selectedIndex = widget.selectedIndex;
+    widget.controller?.addListener(_controllerCallback);
     super.initState();
+  }
+
+  @override
+  void dispose() {
+    widget.controller?.removeListener(_controllerCallback);
+    super.dispose();
+  }
+
+  void _controllerCallback() {
+    _navigator.popUntil((route) => route.isFirst);
+    _onTap(widget.controller!.value);
   }
 
   void _onTap(int index) {

--- a/test/pages/yaru_master_detail_page_test.dart
+++ b/test/pages/yaru_master_detail_page_test.dart
@@ -42,6 +42,47 @@ void main() {
     variant: goldenVariant,
     tags: 'golden',
   );
+
+  testWidgets(
+    'controller',
+    (tester) async {
+      final variant = goldenVariant.currentValue!;
+      final controller = ValueNotifier<int>(0);
+      await tester.pumpScaffold(
+        YaruMasterDetailPage(
+          controller: controller,
+          leftPaneWidth: kYaruMasterDetailBreakpoint / 3,
+          length: 8,
+          appBar: AppBar(title: const Text('Master')),
+          tileBuilder: (context, index, selected) => YaruMasterTile(
+            leading: const Icon(YaruIcons.menu),
+            title: Text('Tile $index'),
+          ),
+          pageBuilder: (context, index) => YaruDetailPage(
+            appBar: AppBar(
+              title: Text('Detail title $index'),
+            ),
+            body: Center(child: Text('Detail body $index')),
+          ),
+        ),
+        themeMode: variant.themeMode,
+        size: Size(variant.value!, 480),
+      );
+
+      controller.value = 3;
+      await tester.pumpAndSettle();
+      if (variant.label.startsWith('portrait')) {
+        expect(find.text('Master'), findsNothing);
+        expect(find.text('Tile 3'), findsNothing);
+      } else if (variant.label.startsWith('landscape')) {
+        expect(find.text('Master'), findsOneWidget);
+        expect(find.text('Tile 3'), findsOneWidget);
+      }
+      expect(find.text('Detail title 3'), findsOneWidget);
+      expect(find.text('Detail body 3'), findsOneWidget);
+    },
+    variant: goldenVariant,
+  );
 }
 
 final goldenVariant = ValueVariant({


### PR DESCRIPTION
Adds a simple controller to `YaruMasterDetailPage` that allows to select the currently selected index.

## Pull request checklist

- [x] Either this PR does not introduce visual changes, or
- [ ] I run `flutter test --update-goldens` and committed the changes if there were any, or
- [ ] I added before/after/light/dark screenshots if the visual changes I made were not covered by golden tests.
