### PR TITLE
Fix YaruCarouselController.startTimer()

### DIFF
--- a/lib/src/utilities/yaru_carousel.dart
+++ b/lib/src/utilities/yaru_carousel.dart
@@ -332,7 +332,7 @@ class YaruCarouselController extends PageController {
   }
 
   void startTimer() {
-    if (autoScroll) {
+    if (autoScroll && hasClients) {
       _timer = Timer(autoScrollDuration, () {
         final carousel = position.context.notificationContext
             ?.findAncestorWidgetOfExactType<YaruCarousel>();


### PR DESCRIPTION
No visual changes.

Don't schedule a timer when no longer attached. This fixes the following exception that occurred while randomly browsing the example.

```
[ERROR:flutter/runtime/dart_vm_initializer.cc(41)] Unhandled Exception: 'package:flutter/src/widgets/scroll_controller.dart':
Failed assertion: line 107 pos 12: '_positions.isNotEmpty': ScrollController not attached to any scroll views.
```