### PR TITLE
Fix: Desktop Web: separator of MD page is super white in the dark theme

### DIFF
--- a/lib/src/layouts/yaru_landscape_layout.dart
+++ b/lib/src/layouts/yaru_landscape_layout.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'yaru_master_detail_page.dart';
@@ -163,6 +164,15 @@ class _YaruLandscapeLayoutState extends State<YaruLandscapeLayout> {
   }
 
   Widget _buildVerticalSeparator() {
+    // Fix for the ultra white divider on flutter web
+    final darkAndWeb =
+        kIsWeb && Theme.of(context).brightness == Brightness.dark;
+    if (darkAndWeb) {
+      return const VerticalDivider(
+        thickness: 0,
+        width: 0.01,
+      );
+    }
     return const VerticalDivider(
       thickness: 1,
       width: 1,


### PR DESCRIPTION
Linux:
![grafik](https://user-images.githubusercontent.com/15329494/202381184-e9e526f4-f442-47c0-9bda-b6fbc6be7c68.png)
![grafik](https://user-images.githubusercontent.com/15329494/202381251-35f83af6-342c-4155-8371-22e96bd42fe5.png)


Web:
![grafik](https://user-images.githubusercontent.com/15329494/202381667-93bdf087-9aeb-4083-ba70-c0fc8d72ab8b.png)
![grafik](https://user-images.githubusercontent.com/15329494/202381735-d9a5cc01-b226-4120-9d8c-013181a191b7.png)


Fixes #305