### PR TITLE
Fix wrong label wrap in page layouts

### DIFF
--- a/example/lib/example.dart
+++ b/example/lib/example.dart
@@ -35,7 +35,7 @@ class _ExampleState extends State<Example> {
   Widget build(BuildContext context) {
     final model = context.watch<ExampleModel>();
     final configItem = PageItem(
-      titleBuilder: (context) => const Text('Layout'),
+      titleBuilder: (context) => YaruOneLineText('Layout'),
       tooltipMessage: 'Layout',
       snippetUrl:
           'https://raw.githubusercontent.com/ubuntu/yaru_widgets.dart/main/lib/src/layouts/yaru_landscape_layout.dart',

--- a/example/lib/example_page_items.dart
+++ b/example/lib/example_page_items.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:yaru_icons/yaru_icons.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
 import 'pages/banner_page.dart';
 import 'pages/carousel_page.dart';
 import 'pages/check_button_page.dart';
@@ -38,7 +39,7 @@ class PageItem {
 
 final examplePageItems = <PageItem>[
   PageItem(
-    titleBuilder: (context) => const Text('Controls'),
+    titleBuilder: (context) => YaruOneLineText('Controls'),
     tooltipMessage: 'Controls',
     snippetUrl:
         'https://raw.githubusercontent.com/ubuntu/yaru_widgets.dart/main/example/lib/pages/controls_page.dart',
@@ -46,7 +47,7 @@ final examplePageItems = <PageItem>[
     iconBuilder: (context, selected) => const Icon(YaruIcons.games),
   ),
   PageItem(
-    titleBuilder: (context) => const Text('YaruBanner'),
+    titleBuilder: (context) => YaruOneLineText('YaruBanner'),
     tooltipMessage: 'YaruBanner',
     snippetUrl:
         'https://raw.githubusercontent.com/ubuntu/yaru_widgets.dart/main/example/lib/pages/banner_page.dart',
@@ -56,7 +57,7 @@ final examplePageItems = <PageItem>[
         : const Icon(YaruIcons.image),
   ),
   PageItem(
-    titleBuilder: (context) => const Text('YaruCarousel'),
+    titleBuilder: (context) => YaruOneLineText('YaruCarousel'),
     tooltipMessage: 'YaruCarousel',
     snippetUrl:
         'https://raw.githubusercontent.com/ubuntu/yaru_widgets.dart/main/example/lib/pages/carousel_page.dart',
@@ -64,7 +65,7 @@ final examplePageItems = <PageItem>[
     iconBuilder: (context, selected) => const Icon(YaruIcons.refresh),
   ),
   PageItem(
-    titleBuilder: (context) => const Text('YaruCheckButton'),
+    titleBuilder: (context) => YaruOneLineText('YaruCheckButton'),
     tooltipMessage: 'YaruCheckButton',
     snippetUrl:
         'https://raw.githubusercontent.com/ubuntu/yaru_widgets.dart/main/example/lib/pages/check_button_page.dart',
@@ -74,7 +75,7 @@ final examplePageItems = <PageItem>[
         : const Icon(YaruIcons.checkbox_button_checked),
   ),
   PageItem(
-    titleBuilder: (context) => const Text('YaruColorDisk'),
+    titleBuilder: (context) => YaruOneLineText('YaruColorDisk'),
     tooltipMessage: 'YaruColorDisk',
     snippetUrl:
         'https://raw.githubusercontent.com/ubuntu/yaru_widgets.dart/main/example/lib/pages/color_disk_page.dart',
@@ -82,7 +83,7 @@ final examplePageItems = <PageItem>[
     iconBuilder: (context, selected) => const Icon(YaruIcons.color_select),
   ),
   PageItem(
-    titleBuilder: (context) => const Text('YaruDraggable'),
+    titleBuilder: (context) => YaruOneLineText('YaruDraggable'),
     tooltipMessage: 'YaruDraggable',
     snippetUrl:
         'https://raw.githubusercontent.com/ubuntu/yaru_widgets.dart/main/example/lib/pages/draffable_page.dart',
@@ -90,7 +91,7 @@ final examplePageItems = <PageItem>[
     iconBuilder: (context, selected) => const Icon(YaruIcons.drag_handle),
   ),
   PageItem(
-    titleBuilder: (context) => const Text('YaruExpandable'),
+    titleBuilder: (context) => YaruOneLineText('YaruExpandable'),
     tooltipMessage: 'YaruExpandable',
     snippetUrl:
         'https://raw.githubusercontent.com/ubuntu/yaru_widgets.dart/main/example/lib/pages/expandable_page.dart',
@@ -98,7 +99,7 @@ final examplePageItems = <PageItem>[
     pageBuilder: (_) => const ExpandablePage(),
   ),
   PageItem(
-    titleBuilder: (context) => const Text('YaruIconButton'),
+    titleBuilder: (context) => YaruOneLineText('YaruIconButton'),
     tooltipMessage: 'YaruIconButton',
     snippetUrl:
         'https://raw.githubusercontent.com/ubuntu/yaru_widgets.dart/main/example/lib/pages/icon_button_page.dart',
@@ -106,7 +107,7 @@ final examplePageItems = <PageItem>[
     pageBuilder: (_) => const IconButtonPage(),
   ),
   PageItem(
-    titleBuilder: (context) => const Text('YaruOptionButton'),
+    titleBuilder: (context) => YaruOneLineText('YaruOptionButton'),
     tooltipMessage: 'YaruOptionButton',
     snippetUrl:
         'https://raw.githubusercontent.com/ubuntu/yaru_widgets.dart/main/example/lib/pages/option_button_page.dart',
@@ -116,7 +117,7 @@ final examplePageItems = <PageItem>[
     pageBuilder: (_) => const OptionButtonPage(),
   ),
   PageItem(
-    titleBuilder: (context) => const Text('YaruPopupMenuButton'),
+    titleBuilder: (context) => YaruOneLineText('YaruPopupMenuButton'),
     tooltipMessage: 'YaruPopupMenuButton',
     snippetUrl:
         'https://raw.githubusercontent.com/ubuntu/yaru_widgets.dart/main/example/lib/pages/option_button_page.dart',
@@ -125,7 +126,7 @@ final examplePageItems = <PageItem>[
     pageBuilder: (_) => const PopupPage(),
   ),
   PageItem(
-    titleBuilder: (context) => const Text('YaruProgressIndicator'),
+    titleBuilder: (context) => YaruOneLineText('YaruProgressIndicator'),
     tooltipMessage: 'YaruProgressIndicator',
     snippetUrl:
         'https://raw.githubusercontent.com/ubuntu/yaru_widgets.dart/main/example/lib/pages/progress_indicator_page.dart',
@@ -133,7 +134,7 @@ final examplePageItems = <PageItem>[
     pageBuilder: (_) => const ProgressIndicatorPage(),
   ),
   PageItem(
-    titleBuilder: (context) => const Text('YaruRadioButton'),
+    titleBuilder: (context) => YaruOneLineText('YaruRadioButton'),
     tooltipMessage: 'YaruRadioButton',
     snippetUrl:
         'https://raw.githubusercontent.com/ubuntu/yaru_widgets.dart/main/example/lib/pages/radio_button_page.dart',
@@ -143,7 +144,7 @@ final examplePageItems = <PageItem>[
         : const Icon(YaruIcons.radio_button_checked),
   ),
   PageItem(
-    titleBuilder: (context) => const Text('YaruSection'),
+    titleBuilder: (context) => YaruOneLineText('YaruSection'),
     tooltipMessage: 'YaruSection',
     snippetUrl:
         'https://raw.githubusercontent.com/ubuntu/yaru_widgets.dart/main/example/lib/pages/section_page.dart',
@@ -151,7 +152,7 @@ final examplePageItems = <PageItem>[
     pageBuilder: (_) => const SectionPage(),
   ),
   PageItem(
-    titleBuilder: (context) => const Text('YaruSelectableContainer'),
+    titleBuilder: (context) => YaruOneLineText('YaruSelectableContainer'),
     tooltipMessage: 'YaruSelectableContainer',
     snippetUrl:
         'https://raw.githubusercontent.com/ubuntu/yaru_widgets.dart/main/example/lib/pages/selectable_container_page.dart',
@@ -159,7 +160,7 @@ final examplePageItems = <PageItem>[
     pageBuilder: (_) => const SelectableContainerPage(),
   ),
   PageItem(
-    titleBuilder: (context) => const Text('YaruSwitchButton'),
+    titleBuilder: (context) => YaruOneLineText('YaruSwitchButton'),
     tooltipMessage: 'YaruSwitchButton',
     snippetUrl:
         'https://raw.githubusercontent.com/ubuntu/yaru_widgets.dart/main/example/lib/pages/switch_button_page.dart',
@@ -169,7 +170,7 @@ final examplePageItems = <PageItem>[
         : const Icon(YaruIcons.switch_button),
   ),
   PageItem(
-    titleBuilder: (context) => const Text('YaruTabbedPage'),
+    titleBuilder: (context) => YaruOneLineText('YaruTabbedPage'),
     tooltipMessage: 'YaruTabbedPage',
     snippetUrl:
         'https://raw.githubusercontent.com/ubuntu/yaru_widgets.dart/main/example/lib/pages/tabbed_page_page.dart',
@@ -177,7 +178,7 @@ final examplePageItems = <PageItem>[
     iconBuilder: (context, selected) => const Icon(YaruIcons.tab_new),
   ),
   PageItem(
-    titleBuilder: (context) => const Text('YaruTile'),
+    titleBuilder: (context) => YaruOneLineText('YaruTile'),
     tooltipMessage: 'YaruTile',
     snippetUrl:
         'https://raw.githubusercontent.com/ubuntu/yaru_widgets.dart/main/example/lib/pages/tile_page.dart',
@@ -186,7 +187,7 @@ final examplePageItems = <PageItem>[
     pageBuilder: (_) => const TilePage(),
   ),
   PageItem(
-    titleBuilder: (context) => const Text('YaruTitleBar'),
+    titleBuilder: (context) => YaruOneLineText('YaruTitleBar'),
     tooltipMessage: 'YaruTitleBar',
     snippetUrl:
         'https://raw.githubusercontent.com/ubuntu/yaru_widgets.dart/main/example/lib/pages/dialog_page.dart',
@@ -196,7 +197,7 @@ final examplePageItems = <PageItem>[
     pageBuilder: (_) => const DialogPage(),
   ),
   PageItem(
-    titleBuilder: (context) => const Text('YaruWindowControl'),
+    titleBuilder: (context) => YaruOneLineText('YaruWindowControl'),
     tooltipMessage: 'YaruWindowControl',
     iconBuilder: (context, selected) => const Icon(YaruIcons.window_top_bar),
     pageBuilder: (_) => const WindowControlsPage(),

--- a/lib/src/layouts/yaru_master_tile.dart
+++ b/lib/src/layouts/yaru_master_tile.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-import '../constants.dart';
+import '../../yaru_widgets.dart';
 
 const double _kScrollbarThickness = 8.0;
 const double _kScrollbarMargin = 2.0;
@@ -27,9 +27,11 @@ class YaruMasterTile extends StatelessWidget {
   final Widget? leading;
 
   /// See [ListTile.title].
+  /// Please prefer to use [YaruOneLineText] to get the correct word break behaviour.
   final Widget? title;
 
   /// See [ListTile.subtitle].
+  /// Please prefer to use [YaruOneLineText] to get the correct word break behaviour.
   final Widget? subtitle;
 
   /// See [ListTile.trailing].

--- a/lib/src/layouts/yaru_navigation_rail_item.dart
+++ b/lib/src/layouts/yaru_navigation_rail_item.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import '../utilities/yaru_one_line_text.dart';
+
 /// Defines the look of a [YaruNavigationRailItem]
 enum YaruNavigationRailStyle {
   /// Will only show icons
@@ -27,11 +29,25 @@ class YaruNavigationRailItem extends StatefulWidget {
     required this.style,
   });
 
+  /// Whatever the related page item is selected in the rail.
   final bool? selected;
+
+  /// Icon widget, displayed agaist the [label].
   final Widget icon;
+
+  /// Label widget, displayed agaist the [icon].
+  /// Please prefer to use [YaruOneLineText] to get the correct word break behaviour.
   final Widget label;
+
+  /// Optional string tooltip.
+  /// If not null a tooltip will be displayed on hover.
+  /// It should describe the whole tile if possible.
   final String? tooltip;
+
+  /// Callback called on tap the tile.
   final VoidCallback? onTap;
+
+  /// Style of this tile, see [YaruNavigationRailStyle].
   final YaruNavigationRailStyle style;
 
   @override

--- a/lib/src/utilities/yaru_one_line_text.dart
+++ b/lib/src/utilities/yaru_one_line_text.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+
+class YaruOneLineText extends Text {
+  YaruOneLineText(
+    String data, {
+    super.key,
+    super.style,
+    super.strutStyle,
+    super.textAlign,
+    super.textDirection,
+    super.locale,
+    super.softWrap,
+    super.overflow,
+    super.textScaleFactor,
+    super.semanticsLabel,
+    super.textWidthBasis,
+    super.textHeightBehavior,
+    super.selectionColor,
+  }) : super(
+          data.replaceAll(' ', '\u00A0'),
+          maxLines: 1,
+        );
+}

--- a/lib/yaru_widgets.dart
+++ b/lib/yaru_widgets.dart
@@ -42,4 +42,5 @@ export 'src/utilities/yaru_carousel.dart';
 export 'src/utilities/yaru_draggable.dart';
 export 'src/utilities/yaru_expandable.dart';
 export 'src/utilities/yaru_expansion_panel_list.dart';
+export 'src/utilities/yaru_one_line_text.dart';
 export 'src/utilities/yaru_selectable_container.dart';


### PR DESCRIPTION
- Create `YaruOneLineText` widget.
- Add missing comments in `YaruNavigationRailItem`.

Fixes #259

## Pull request checklist

- [x]  I added before/after/light/dark screenshots if the visual changes I made were not covered by golden tests.
    
| |Before|After|
|-|-|-|
|Light| ![Capture d’écran du 2022-11-19 11-14-38](https://user-images.githubusercontent.com/36476595/202846401-62902653-0a21-4572-8248-f4558df15288.png) | ![Capture d’écran du 2022-11-19 11-14-32](https://user-images.githubusercontent.com/36476595/202846406-2fca7210-95f3-41ca-89f9-1b8a5e2672e5.png) |
|Dark| ![Capture d’écran du 2022-11-19 11-27-23](https://user-images.githubusercontent.com/36476595/202846409-4ee2b550-7d60-4ed3-b22f-a35139b7e241.png) | ![Capture d’écran du 2022-11-19 11-27-11](https://user-images.githubusercontent.com/36476595/202846413-da92384b-8560-4d57-b75d-9c2d6e3fb28f.png) |

**Edit:** sorry for the push mess, I force pushed by mistake an empty commit 🤕