### PR TITLE
Toggle buttons: don't expand horizontally

### DIFF
--- a/lib/src/controls/yaru_toggle_button_layout.dart
+++ b/lib/src/controls/yaru_toggle_button_layout.dart
@@ -198,8 +198,9 @@ class _YaruRenderToggleButton extends RenderBox
     );
 
     final titleX = leadingSize.width + horizontalSpacing;
-    final textConstraints = loosened.tighten(width: availableWidth - titleX);
-
+    final textConstraints = constraints
+        .copyWith(maxWidth: constraints.maxWidth - titleX)
+        .normalize();
     final titleSize = _layoutBox(title, textConstraints);
     final subtitleSize = _layoutBox(subtitle, textConstraints);
 

--- a/test/controls/yaru_check_button_test.dart
+++ b/test/controls/yaru_check_button_test.dart
@@ -168,6 +168,7 @@ void main() {
         ),
         themeMode: variant.themeMode,
         size: const Size(224, 56),
+        alignment: Alignment.centerLeft,
       );
       await tester.pumpAndSettle();
 

--- a/test/controls/yaru_radio_button_test.dart
+++ b/test/controls/yaru_radio_button_test.dart
@@ -179,6 +179,7 @@ void main() {
         ),
         themeMode: variant.themeMode,
         size: const Size(224, 56),
+        alignment: Alignment.centerLeft,
       );
       await tester.pumpAndSettle();
 

--- a/test/controls/yaru_switch_button_test.dart
+++ b/test/controls/yaru_switch_button_test.dart
@@ -165,6 +165,7 @@ void main() {
         ),
         themeMode: variant.themeMode,
         size: const Size(248, 56),
+        alignment: Alignment.centerLeft,
       );
       await tester.pumpAndSettle();
 

--- a/test/controls/yaru_toggle_button_test.dart
+++ b/test/controls/yaru_toggle_button_test.dart
@@ -91,13 +91,13 @@ void main() {
 
     expect(titleRect.left, greaterThan(leadingRect.right));
     expect(titleRect.center.dy, leadingRect.center.dy);
-    expect(titleRect.right, buttonRect.right);
-    expect(titleRect.width, 192);
+    expect(titleRect.right, lessThan(buttonRect.right));
+    expect(titleRect.width, 128);
     expect(titleRect.height, 24);
 
     expect(subtitleRect.left, titleRect.left);
     expect(subtitleRect.top, greaterThan(titleRect.bottom));
-    expect(subtitleRect.right, titleRect.right);
+    expect(subtitleRect.right, greaterThan(titleRect.right));
     expect(subtitleRect.bottom, buttonRect.bottom);
     expect(subtitleRect.width, 192);
     expect(subtitleRect.height, 16);
@@ -195,12 +195,12 @@ void main() {
     expect(titleRect.left, buttonRect.left);
     expect(titleRect.center.dy, leadingRect.center.dy);
     expect(titleRect.right, lessThan(leadingRect.left));
-    expect(titleRect.width, 192);
+    expect(titleRect.width, 128);
     expect(titleRect.height, 24);
 
     expect(subtitleRect.left, titleRect.left);
     expect(subtitleRect.top, greaterThan(titleRect.bottom));
-    expect(subtitleRect.right, titleRect.right);
+    expect(subtitleRect.right, greaterThan(titleRect.right));
     expect(subtitleRect.bottom, buttonRect.bottom);
     expect(subtitleRect.width, 192);
     expect(subtitleRect.height, 16);
@@ -240,8 +240,8 @@ void main() {
 
     expect(titleRect.left, leadingRect.right + 24);
     expect(titleRect.center.dy, leadingRect.center.dy);
-    expect(titleRect.right, buttonRect.right);
-    expect(titleRect.width, 192);
+    expect(titleRect.right, lessThan(subtitleRect.right));
+    expect(titleRect.width, 128);
     expect(titleRect.height, 24);
 
     expect(subtitleRect.left, titleRect.left);
@@ -331,7 +331,7 @@ extension YaruToggleButtonTester on WidgetTester {
         textDirection: textDirection,
         child: Scaffold(
           body: Center(
-            child: IntrinsicWidth(child: widget),
+            child: widget,
           ),
         ),
       ),

--- a/test/yaru_golden_tester.dart
+++ b/test/yaru_golden_tester.dart
@@ -11,6 +11,7 @@ extension YaruGoldenTester on WidgetTester {
     ThemeData? theme,
     ThemeData? darkTheme,
     Size? size,
+    AlignmentGeometry alignment = Alignment.center,
   }) {
     binding.window.devicePixelRatioTestValue = 1;
     if (size != null) binding.window.physicalSizeTestValue = size;
@@ -21,7 +22,10 @@ extension YaruGoldenTester on WidgetTester {
         darkTheme: darkTheme ?? yaruDark,
         debugShowCheckedModeBanner: false,
         home: Scaffold(
-          body: Center(child: widget),
+          body: Align(
+            child: widget,
+            alignment: alignment,
+          ),
         ),
       ),
     );


### PR DESCRIPTION
Don't expand the title and subtitle to infinite width (like ListTile does) but keep them at their intrinsic widths like check and radio buttons usually do on the desktop.

| Before | After |
|---|---|
| ![Screenshot from 2022-11-23 22-06-45](https://user-images.githubusercontent.com/140617/203855393-0de98d9e-d758-4d21-ad9e-56f796c4c51c.png) | ![Screenshot from 2022-11-23 22-41-21](https://user-images.githubusercontent.com/140617/203855396-f5c30040-93f6-4e15-a050-5fd7ff2a57a0.png) |