### PR TITLE
YaruBanner: don't ignore the surface tint color when no watermark is set

### DIFF
--- a/lib/src/utilities/yaru_banner.dart
+++ b/lib/src/utilities/yaru_banner.dart
@@ -88,7 +88,7 @@ class YaruBanner extends StatelessWidget {
                 title: title,
                 subtitle: subtitle,
                 borderRadius: borderRadius,
-                color: defaultCardColor,
+                color: surfaceTintColor ?? defaultCardColor,
                 elevation: light ? 2 : 1,
                 mouseCursor: onTap != null ? SystemMouseCursors.click : null,
               ),


### PR DESCRIPTION
The example with watermarks removed:

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/140617/204643439-3f692948-acd1-4a87-a940-a23d3180f906.png) | ![image](https://user-images.githubusercontent.com/140617/204643372-7dfd76df-9ddb-4a2e-b10a-0a0b92a0f7d8.png) |
