### PR TITLE
YaruBanner: align tint/elevation with and without watermark

### DIFF
--- a/lib/src/utilities/yaru_banner.dart
+++ b/lib/src/utilities/yaru_banner.dart
@@ -54,44 +54,32 @@ class YaruBanner extends StatelessWidget {
         onTap: onTap,
         borderRadius: borderRadius,
         hoverColor: Theme.of(context).colorScheme.onSurface.withOpacity(0.1),
-        child: copyIconAsWatermark
-            ? Stack(
-                alignment: Alignment.center,
-                children: [
-                  _Banner(
-                    icon: icon,
-                    iconPadding: iconPadding,
-                    title: title,
-                    subtitle: subtitle,
-                    borderRadius: borderRadius,
-                    color: surfaceTintColor ?? defaultCardColor,
-                    elevation: light ? 4 : 6,
-                    mouseCursor:
-                        onTap != null ? SystemMouseCursors.click : null,
+        child: Stack(
+          alignment: Alignment.center,
+          children: [
+            _Banner(
+              icon: icon,
+              iconPadding: iconPadding,
+              title: title,
+              subtitle: subtitle,
+              borderRadius: borderRadius,
+              color: surfaceTintColor ?? defaultCardColor,
+              elevation: light ? 4 : 6,
+              mouseCursor: onTap != null ? SystemMouseCursors.click : null,
+            ),
+            if (copyIconAsWatermark == true)
+              Padding(
+                padding: const EdgeInsets.only(right: 20),
+                child: Align(
+                  alignment: Alignment.centerRight,
+                  child: Opacity(
+                    opacity: 0.1,
+                    child: watermarkIcon != null ? watermarkIcon! : icon,
                   ),
-                  if (copyIconAsWatermark == true)
-                    Padding(
-                      padding: const EdgeInsets.only(right: 20),
-                      child: Align(
-                        alignment: Alignment.centerRight,
-                        child: Opacity(
-                          opacity: 0.1,
-                          child: watermarkIcon != null ? watermarkIcon! : icon,
-                        ),
-                      ),
-                    ),
-                ],
-              )
-            : _Banner(
-                icon: icon,
-                iconPadding: iconPadding,
-                title: title,
-                subtitle: subtitle,
-                borderRadius: borderRadius,
-                color: surfaceTintColor ?? defaultCardColor,
-                elevation: light ? 2 : 1,
-                mouseCursor: onTap != null ? SystemMouseCursors.click : null,
+                ),
               ),
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
Use the same tint shade (elevation) regardless of whether a watermark is specified for consistent and predictable results.

### Before
[Screencast from 2022-11-29 21-58-03.webm](https://user-images.githubusercontent.com/140617/204646779-019b3637-32eb-411f-93b6-32b805430c59.webm)

### After
[Screencast from 2022-11-29 21-58-41.webm](https://user-images.githubusercontent.com/140617/204646920-451eee55-b40c-47c6-b863-6962cae2d820.webm)