### PR TITLE
YaruBanner: clean up unused internal mouse cursor property

### DIFF
--- a/lib/src/utilities/yaru_banner.dart
+++ b/lib/src/utilities/yaru_banner.dart
@@ -65,7 +65,6 @@ class YaruBanner extends StatelessWidget {
               borderRadius: borderRadius,
               color: surfaceTintColor ?? defaultCardColor,
               elevation: light ? 4 : 6,
-              mouseCursor: onTap != null ? SystemMouseCursors.click : null,
             ),
             if (copyIconAsWatermark == true)
               Padding(
@@ -92,7 +91,6 @@ class _Banner extends StatelessWidget {
     required this.elevation,
     required this.icon,
     required this.borderRadius,
-    this.mouseCursor,
     this.subtitle,
     required this.iconPadding,
   });
@@ -102,7 +100,6 @@ class _Banner extends StatelessWidget {
   final double elevation;
   final Widget icon;
   final BorderRadius borderRadius;
-  final MouseCursor? mouseCursor;
   final Widget? subtitle;
   final EdgeInsets iconPadding;
 


### PR DESCRIPTION
The click mouse cursor is provided by the InkWell above the card.

## Pull request checklist

- [x] This PR does not introduce visual changes, **or**
  - I ran `flutter test --update-goldens` and committed the changes if there were any, **or**
  - I added before/after/light/dark screenshots if the visual changes I made were not covered by golden tests.
    | |Before|After|
    |-|-|-|
    |Light| | |
    |Dark| | |