### PR TITLE
YaruBanner: remove effectively unused copyIconAsWatermark

### DIFF
--- a/example/lib/pages/banner_page.dart
+++ b/example/lib/pages/banner_page.dart
@@ -32,7 +32,6 @@ class BannerPage extends StatelessWidget {
               size: 80,
               color: Theme.of(context).primaryColor,
             ),
-            copyIconAsWatermark: true,
             onTap: () => showAboutDialog(context: context),
             surfaceTintColor: i.isEven ? Colors.pink : null,
             watermarkIcon: const Icon(

--- a/lib/src/utilities/yaru_banner.dart
+++ b/lib/src/utilities/yaru_banner.dart
@@ -7,7 +7,6 @@ class YaruBanner extends StatelessWidget {
     super.key,
     this.onTap,
     this.surfaceTintColor,
-    this.copyIconAsWatermark = false,
     required this.title,
     required this.icon,
     this.subtitle,
@@ -27,9 +26,6 @@ class YaruBanner extends StatelessWidget {
   /// The color used for the soft background tint.
   /// If null [Theme]'s background color is used.
   final Color? surfaceTintColor;
-
-  /// If true the [icon] will be displayed a second time, with small opacity.
-  final bool copyIconAsWatermark;
 
   /// The [Widget] used as the leading icon.
   final Widget icon;
@@ -67,14 +63,14 @@ class YaruBanner extends StatelessWidget {
               elevation: light ? 4 : 6,
               mouseCursor: onTap != null ? SystemMouseCursors.click : null,
             ),
-            if (copyIconAsWatermark == true)
+            if (watermarkIcon != null)
               Padding(
                 padding: const EdgeInsets.only(right: 20),
                 child: Align(
                   alignment: Alignment.centerRight,
                   child: Opacity(
                     opacity: 0.1,
-                    child: watermarkIcon != null ? watermarkIcon! : icon,
+                    child: watermarkIcon,
                   ),
                 ),
               ),


### PR DESCRIPTION
There's one occurrence of `copyIconAsWatermark` in the `yaru_widgets.dart` example, and another in the software app. Both of them pass `watermarkIcon` so neither is actually "copying" the leading icon as a watermark. This PR is a proposal to make the API more intuitive and just check if `watermarkIcon != null`. One can pass the same widget to both properties if that's desired.

## Pull request checklist

- [x] This PR does not introduce visual changes, **or**
  - I ran `flutter test --update-goldens` and committed the changes if there were any, **or**
  - I added before/after/light/dark screenshots if the visual changes I made were not covered by golden tests.
    | |Before|After|
    |-|-|-|
    |Light| | |
    |Dark| | |