### PR TITLE
YaruLandscapeLayout: remove docs from an internal helper class

### DIFF
--- a/lib/src/layouts/yaru_landscape_layout.dart
+++ b/lib/src/layouts/yaru_landscape_layout.dart
@@ -10,7 +10,6 @@ import 'yaru_master_list_view.dart';
 import 'yaru_page_controller.dart';
 
 class YaruLandscapeLayout extends StatefulWidget {
-  /// Creates a landscape layout
   const YaruLandscapeLayout({
     super.key,
     required this.tileBuilder,
@@ -23,28 +22,13 @@ class YaruLandscapeLayout extends StatefulWidget {
     required this.controller,
   });
 
-  /// A builder that is called for each page to build its master tile.
   final YaruMasterDetailBuilder tileBuilder;
-
-  /// A builder that is called for each page to build its detail page.
   final IndexedWidgetBuilder pageBuilder;
-
-  /// Callback that returns an index when the page changes.
   final ValueChanged<int>? onSelected;
-
-  /// Controls the pane width with defined parameters
   final YaruMasterDetailPaneLayoutDelegate layoutDelegate;
-
-  /// Previous width of the pane
   final double? previousPaneWidth;
-
-  /// Callback called when the left pane is resizing.
   final Function(double)? onLeftPaneWidthChange;
-
-  /// An optional [PreferredSizeWidget] used as the left [AppBar]
-  /// If provided, a second [AppBar] will be created right to it.
   final PreferredSizeWidget? appBar;
-
   final YaruPageController controller;
 
   @override


### PR DESCRIPTION
`YaruLandscapeLayout` is an internal helper class. It's not exported from `lib/yaru_widgets.dart`. Its sibling `YaruPortraitLayout` doesn't have docs either.

The docs are not only annoying to maintain but also cause confusion in code reviews. Having docs makes it look like a public class. The class gets easily mixed up with `YaruCompactLayout` with a similar name that on the other hand is a public class.