### PR TITLE
Fix RTL support for paddings and margins

### DIFF
--- a/lib/src/controls/yaru_checkbox.dart
+++ b/lib/src/controls/yaru_checkbox.dart
@@ -116,7 +116,8 @@ class YaruCheckbox extends StatefulWidget implements YaruTogglable<bool?> {
 
 class _YaruCheckboxState extends YaruTogglableState<YaruCheckbox> {
   @override
-  EdgeInsets get activableAreaPadding => kCheckradioActivableAreaPadding;
+  EdgeInsetsGeometry get activableAreaPadding =>
+      kCheckradioActivableAreaPadding;
 
   @override
   Size get togglableSize => kCheckradioTogglableSize;

--- a/lib/src/controls/yaru_icon_button.dart
+++ b/lib/src/controls/yaru_icon_button.dart
@@ -32,7 +32,7 @@ class YaruIconButton extends StatelessWidget {
   final bool? isSelected;
   final MouseCursor? mouseCursor;
   final VoidCallback? onPressed;
-  final EdgeInsets padding;
+  final EdgeInsetsGeometry padding;
   final Widget? selectedIcon;
   final double? splashRadius;
   final ButtonStyle? style;

--- a/lib/src/controls/yaru_option_button.dart
+++ b/lib/src/controls/yaru_option_button.dart
@@ -51,7 +51,7 @@ class YaruOptionButton extends OutlinedButton {
           ),
         );
 
-  static ButtonStyle _styleFrom({EdgeInsets? padding}) {
+  static ButtonStyle _styleFrom({EdgeInsetsGeometry? padding}) {
     return OutlinedButton.styleFrom(
       minimumSize: const Size.square(40),
       maximumSize: const Size.square(40),

--- a/lib/src/controls/yaru_popup_menu_button.dart
+++ b/lib/src/controls/yaru_popup_menu_button.dart
@@ -30,8 +30,8 @@ class YaruPopupMenuButton<T> extends StatelessWidget {
   final String? tooltip;
   final PopupMenuPosition position;
   final List<PopupMenuEntry<T>> Function(BuildContext) itemBuilder;
-  final EdgeInsets padding;
-  final EdgeInsets childPadding;
+  final EdgeInsetsGeometry padding;
+  final EdgeInsetsGeometry childPadding;
   final bool enabled;
   final Offset offset;
   final bool? enableFeedback;
@@ -78,8 +78,8 @@ class _YaruPopupDecoration extends StatelessWidget {
   });
 
   final Widget child;
-  final EdgeInsets padding;
-  final EdgeInsets childPadding;
+  final EdgeInsetsGeometry padding;
+  final EdgeInsetsGeometry childPadding;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/controls/yaru_radio.dart
+++ b/lib/src/controls/yaru_radio.dart
@@ -126,7 +126,8 @@ class YaruRadio<T> extends StatefulWidget implements YaruTogglable<T?> {
 
 class _YaruRadioState<T> extends YaruTogglableState<YaruRadio<T?>> {
   @override
-  EdgeInsets get activableAreaPadding => kCheckradioActivableAreaPadding;
+  EdgeInsetsGeometry get activableAreaPadding =>
+      kCheckradioActivableAreaPadding;
 
   @override
   Size get togglableSize => kCheckradioTogglableSize;

--- a/lib/src/controls/yaru_switch.dart
+++ b/lib/src/controls/yaru_switch.dart
@@ -95,7 +95,7 @@ class YaruSwitch extends StatefulWidget implements YaruTogglable<bool> {
 
 class _YaruSwitchState extends YaruTogglableState<YaruSwitch> {
   @override
-  EdgeInsets get activableAreaPadding => _kSwitchActivableAreaPadding;
+  EdgeInsetsGeometry get activableAreaPadding => _kSwitchActivableAreaPadding;
 
   @override
   Size get togglableSize => _kSwitchSize;

--- a/lib/src/controls/yaru_togglable.dart
+++ b/lib/src/controls/yaru_togglable.dart
@@ -74,7 +74,7 @@ abstract class YaruTogglableState<S extends YaruTogglable> extends State<S>
     ActivateIntent: CallbackAction<ActivateIntent>(onInvoke: handleTap),
   };
 
-  EdgeInsets get activableAreaPadding;
+  EdgeInsetsGeometry get activableAreaPadding;
   Size get togglableSize;
 
   @override

--- a/lib/src/layouts/yaru_master_detail_theme.dart
+++ b/lib/src/layouts/yaru_master_detail_theme.dart
@@ -33,7 +33,7 @@ class YaruMasterDetailThemeData with Diagnosticable {
   final double? tileSpacing;
 
   /// The padding around the master list.
-  final EdgeInsets? listPadding;
+  final EdgeInsetsGeometry? listPadding;
 
   /// The page transitions to use when in portrait mode.
   final PageTransitionsTheme? portraitTransitions;
@@ -46,7 +46,7 @@ class YaruMasterDetailThemeData with Diagnosticable {
   YaruMasterDetailThemeData copyWith({
     double? breakpoint,
     double? tileSpacing,
-    EdgeInsets? listPadding,
+    EdgeInsetsGeometry? listPadding,
     PageTransitionsTheme? portraitTransitions,
     PageTransitionsTheme? landscapeTransitions,
   }) {

--- a/lib/src/pages/yaru_section.dart
+++ b/lib/src/pages/yaru_section.dart
@@ -29,13 +29,13 @@ class YaruSection extends StatelessWidget {
 
   /// The padding between the section border and its [child] which defaults to
   /// `EdgeInsets.all(8.0)`.
-  final EdgeInsets padding;
+  final EdgeInsetsGeometry padding;
 
   /// The padding around the [headline] which defaults to `EdgeInsets.all(8.0)`.
-  final EdgeInsets headlinePadding;
+  final EdgeInsetsGeometry headlinePadding;
 
   /// An optional margin around the section border.
-  final EdgeInsets? margin;
+  final EdgeInsetsGeometry? margin;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/pages/yaru_tabbed_page.dart
+++ b/lib/src/pages/yaru_tabbed_page.dart
@@ -34,7 +34,7 @@ class YaruTabbedPage extends StatefulWidget {
   final double? width;
 
   /// The padding [EdgeInsets] which defaults to [kDefaultPadding] at top, right and left.
-  final EdgeInsets padding;
+  final EdgeInsetsGeometry padding;
 
   /// The initialIndex of the [TabController]
   final int initialIndex;

--- a/lib/src/pages/yaru_tile.dart
+++ b/lib/src/pages/yaru_tile.dart
@@ -42,8 +42,8 @@ class YaruTile extends StatelessWidget {
   /// Whether or not we can interact with the widget
   final bool enabled;
 
-  /// The padding [EdgeInsets] which defaults to `EdgeInsets.all(8.0)`.
-  final EdgeInsets padding;
+  /// The padding [EdgeInsetsGeometry] which defaults to `EdgeInsets.all(8.0)`.
+  final EdgeInsetsGeometry padding;
 
   /// The style of the tile. Defaults to `YaruTileStyle.normal`.
   final YaruTileStyle style;

--- a/lib/src/utilities/yaru_banner.dart
+++ b/lib/src/utilities/yaru_banner.dart
@@ -30,7 +30,7 @@ class YaruBanner extends StatelessWidget {
   final Widget icon;
 
   /// Padding for the banner content. Defaults to `EdgeInsets.all(kYaruPagePadding)`
-  final EdgeInsets padding;
+  final EdgeInsetsGeometry padding;
 
   @override
   Widget build(BuildContext context) {
@@ -77,7 +77,7 @@ class _Banner extends StatelessWidget {
   final Widget icon;
   final BorderRadius borderRadius;
   final Widget? subtitle;
-  final EdgeInsets padding;
+  final EdgeInsetsGeometry padding;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/utilities/yaru_border_container.dart
+++ b/lib/src/utilities/yaru_border_container.dart
@@ -29,7 +29,7 @@ class YaruBorderContainer extends StatelessWidget {
   final AlignmentGeometry? alignment;
 
   /// See [Container.padding].
-  final EdgeInsets? padding;
+  final EdgeInsetsGeometry? padding;
 
   /// See [Container.color].
   final Color? color;

--- a/lib/src/utilities/yaru_selectable_container.dart
+++ b/lib/src/utilities/yaru_selectable_container.dart
@@ -37,7 +37,7 @@ class YaruSelectableContainer extends StatelessWidget {
   final double radius;
 
   /// Optional custom padding for the child which defaults to 6.0 on all sides.
-  final EdgeInsets? padding;
+  final EdgeInsetsGeometry? padding;
 
   /// Optional custom [Color] which is used for the selection border.
   final Color? selectionColor;
@@ -62,7 +62,8 @@ class YaruSelectableContainer extends StatelessWidget {
         child: Padding(
           padding: padding,
           child: ClipRRect(
-            borderRadius: borderRadius.inner(padding),
+            borderRadius:
+                borderRadius.inner(padding.resolve(Directionality.of(context))),
             child: child,
           ),
         ),

--- a/lib/src/utilities/yaru_watermark.dart
+++ b/lib/src/utilities/yaru_watermark.dart
@@ -31,7 +31,7 @@ class YaruWatermark extends StatelessWidget {
 
   /// The amount of space by which to inset the [watermark]. Defaults to
   /// `EdgeInsets.all(20)`.
-  final EdgeInsets padding;
+  final EdgeInsetsGeometry padding;
 
   /// The opacity of the watermark. Defaults to 0.1.
   final double opacity;


### PR DESCRIPTION
Make sure to use the text direction -agnostic `EdgeInsetsGeometry` instead of the LTR-specific `EdgeInsets` everywhere. This way, users can pass `EdgeInsetsDirectional` to support RTL where appropriate.