### PR TITLE
YaruBanner: allow arbitrary child & offer tile for convenience

### DIFF
--- a/example/lib/pages/banner_page.dart
+++ b/example/lib/pages/banner_page.dart
@@ -23,7 +23,7 @@ class BannerPage extends StatelessWidget {
               Icons.cloud,
               size: 100,
             ),
-            child: YaruBanner(
+            child: YaruBanner.tile(
               title: Text('YaruBanner $i'),
               subtitle: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,

--- a/example/lib/pages/dialog_page.dart
+++ b/example/lib/pages/dialog_page.dart
@@ -53,7 +53,7 @@ class _DialogPageState extends State<DialogPage> {
                       ),
                       content: SizedBox(
                         height: 100,
-                        child: YaruBanner(
+                        child: YaruBanner.tile(
                           surfaceTintColor: Colors.pink,
                           title: Text(
                             isCloseable

--- a/example/lib/pages/tabbed_page_page.dart
+++ b/example/lib/pages/tabbed_page_page.dart
@@ -30,7 +30,7 @@ class _TabbedPagePageState extends State<TabbedPagePage> {
           ),
           children: [
             for (int i = 0; i < 20; i++)
-              YaruBanner(
+              YaruBanner.tile(
                 title: Text('YaruBanner $i'),
                 subtitle: const Text('Description'),
                 icon: Image.asset('assets/ubuntuhero.jpg'),

--- a/lib/src/utilities/yaru_banner.dart
+++ b/lib/src/utilities/yaru_banner.dart
@@ -3,21 +3,39 @@ import '../../yaru_widgets.dart';
 
 /// A colorable [Card] with a border which is tap-able via an [onTap] callback.
 class YaruBanner extends StatelessWidget {
+  /// Creates a banner with an arbitrary child widget.
   const YaruBanner({
     super.key,
     this.onTap,
     this.surfaceTintColor,
-    required this.title,
-    required this.icon,
-    this.subtitle,
+    required this.child,
     this.padding = const EdgeInsets.all(kYaruPagePadding),
   });
 
-  /// The name of the card
-  final Widget title;
+  /// Creates a banner with a [YaruTile] child widget.
+  YaruBanner.tile({
+    Key? key,
+    VoidCallback? onTap,
+    Color? surfaceTintColor,
+    required Widget title,
+    Widget? icon,
+    Widget? subtitle,
+    EdgeInsetsGeometry padding = const EdgeInsets.all(kYaruPagePadding),
+  }) : this(
+          key: key,
+          onTap: onTap,
+          padding: EdgeInsets.zero,
+          surfaceTintColor: surfaceTintColor,
+          child: YaruTile(
+            leading: icon,
+            title: title,
+            subtitle: subtitle,
+            padding: padding,
+          ),
+        );
 
-  /// The subtitle shown in the second line.
-  final Widget? subtitle;
+  /// The widget to display inside the banner.
+  final Widget child;
 
   /// An optional callback
   final Function()? onTap;
@@ -25,9 +43,6 @@ class YaruBanner extends StatelessWidget {
   /// The color used for the soft background tint.
   /// If null [Theme]'s background color is used.
   final Color? surfaceTintColor;
-
-  /// The [Widget] used as the leading icon.
-  final Widget icon;
 
   /// Padding for the banner content. Defaults to `EdgeInsets.all(kYaruPagePadding)`
   final EdgeInsetsGeometry padding;
@@ -46,58 +61,21 @@ class YaruBanner extends StatelessWidget {
         onTap: onTap,
         borderRadius: borderRadius,
         hoverColor: Theme.of(context).colorScheme.onSurface.withOpacity(0.1),
-        child: _Banner(
-          icon: icon,
-          padding: padding,
-          title: title,
-          subtitle: subtitle,
-          borderRadius: borderRadius,
-          color: surfaceTintColor ?? defaultCardColor,
+        child: Card(
+          shadowColor: Colors.transparent,
+          surfaceTintColor: surfaceTintColor ?? defaultCardColor,
           elevation: light ? 4 : 6,
-        ),
-      ),
-    );
-  }
-}
-
-class _Banner extends StatelessWidget {
-  const _Banner({
-    required this.color,
-    required this.title,
-    required this.elevation,
-    required this.icon,
-    required this.borderRadius,
-    this.subtitle,
-    required this.padding,
-  });
-
-  final Color color;
-  final Widget title;
-  final double elevation;
-  final Widget icon;
-  final BorderRadius borderRadius;
-  final Widget? subtitle;
-  final EdgeInsetsGeometry padding;
-
-  @override
-  Widget build(BuildContext context) {
-    return Card(
-      shadowColor: Colors.transparent,
-      surfaceTintColor: color,
-      elevation: elevation,
-      shape: RoundedRectangleBorder(
-        borderRadius: borderRadius
-            .inner(const EdgeInsets.all(4.0)), // 4 is the default margin
-        side: BorderSide(color: Theme.of(context).dividerColor, width: 1),
-      ),
-      child: ConstrainedBox(
-        constraints: const BoxConstraints.expand(),
-        child: YaruTile(
-          padding: padding,
-          style: YaruTileStyle.banner,
-          title: title,
-          subtitle: subtitle,
-          leading: icon,
+          shape: RoundedRectangleBorder(
+            borderRadius: borderRadius
+                .inner(const EdgeInsets.all(4.0)), // 4 is the default margin
+            side: BorderSide(color: Theme.of(context).dividerColor, width: 1),
+          ),
+          child: Container(
+            width: double.infinity,
+            height: double.infinity,
+            padding: padding,
+            child: child,
+          ),
         ),
       ),
     );


### PR DESCRIPTION
The current tile-based layout is offered via a named `YaruBanner.tile` constructor. It offers the exact same looks as before:

![image](https://user-images.githubusercontent.com/140617/204798536-693a62f9-ed66-4fd5-93cf-8c593e0c0e70.png)

The default constructor allows you to pass an arbitrary child widget so you can change the layout as you wish. Here's a simple centered column as a proof of concept:

![image](https://user-images.githubusercontent.com/140617/204798852-8d6aa4d6-47cc-424a-b494-c6bd696f4d15.png)

Close: #422
