### PR TITLE
Fix YaruIconButton.alignment type

### DIFF
--- a/lib/src/controls/yaru_icon_button.dart
+++ b/lib/src/controls/yaru_icon_button.dart
@@ -22,7 +22,7 @@ class YaruIconButton extends StatelessWidget {
     super.key,
   });
 
-  final Alignment alignment;
+  final AlignmentGeometry alignment;
   final bool autofocus;
   final BoxConstraints? constraints;
   final bool enableFeedback;


### PR DESCRIPTION
For the same LTR vs. RTL reasons as `EdgeInsets` vs. `EdgeInsetsGeometry`, we should use text direction -agnostic `AlignmentGeometry` instead of the LTR-specific `Alignment` in the API.