### PR TITLE
Reduce repetitive Theme.of() calls

### DIFF
--- a/lib/src/layouts/yaru_master_tile.dart
+++ b/lib/src/layouts/yaru_master_tile.dart
@@ -40,6 +40,7 @@ class YaruMasterTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     final scope = YaruMasterTileScope.maybeOf(context);
     final isSelected = selected ?? scope?.selected ?? false;
     final scrollbarThicknessWithTrack =
@@ -52,13 +53,12 @@ class YaruMasterTile extends StatelessWidget {
         decoration: BoxDecoration(
           borderRadius:
               const BorderRadius.all(Radius.circular(kYaruButtonRadius)),
-          color: isSelected
-              ? Theme.of(context).colorScheme.onSurface.withOpacity(0.07)
-              : null,
+          color:
+              isSelected ? theme.colorScheme.onSurface.withOpacity(0.07) : null,
         ),
         child: ListTile(
-          selectedColor: Theme.of(context).colorScheme.onSurface,
-          iconColor: Theme.of(context).colorScheme.onSurface.withOpacity(0.8),
+          selectedColor: theme.colorScheme.onSurface,
+          iconColor: theme.colorScheme.onSurface.withOpacity(0.8),
           visualDensity: const VisualDensity(horizontal: -4, vertical: -4),
           shape: const RoundedRectangleBorder(
             borderRadius: BorderRadius.all(Radius.circular(kYaruButtonRadius)),

--- a/lib/src/utilities/yaru_banner.dart
+++ b/lib/src/utilities/yaru_banner.dart
@@ -49,18 +49,19 @@ class YaruBanner extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     final borderRadius = BorderRadius.circular(10);
 
-    final light = Theme.of(context).brightness == Brightness.light;
+    final light = theme.brightness == Brightness.light;
     final defaultCardColor = light
-        ? Theme.of(context).colorScheme.background
-        : Theme.of(context).colorScheme.onSurface.withOpacity(0.01);
+        ? theme.colorScheme.background
+        : theme.colorScheme.onSurface.withOpacity(0.01);
     return Material(
       color: Colors.transparent,
       child: InkWell(
         onTap: onTap,
         borderRadius: borderRadius,
-        hoverColor: Theme.of(context).colorScheme.onSurface.withOpacity(0.1),
+        hoverColor: theme.colorScheme.onSurface.withOpacity(0.1),
         child: Card(
           shadowColor: Colors.transparent,
           surfaceTintColor: surfaceTintColor ?? defaultCardColor,
@@ -68,7 +69,7 @@ class YaruBanner extends StatelessWidget {
           shape: RoundedRectangleBorder(
             borderRadius: borderRadius
                 .inner(const EdgeInsets.all(4.0)), // 4 is the default margin
-            side: BorderSide(color: Theme.of(context).dividerColor, width: 1),
+            side: BorderSide(color: theme.dividerColor, width: 1),
           ),
           child: Container(
             width: double.infinity,


### PR DESCRIPTION
It's not an expensive call, but not free either. Every `Theme.of()` call implies a `Localizations.of()` call, so two inherited widget lookups both of which are basically hashmap lookups. Last but not least, the two are merged and cached, resulting in a third hashmap lookup. Therefore it's nice to store the theme data to a variable at the beginning of `build()` to avoid repeating the hashmap lookups several times.

```dart
  static ThemeData of(BuildContext context) {
    final _InheritedTheme? inheritedTheme = context.dependOnInheritedWidgetOfExactType<_InheritedTheme>(); // <== 1
    final MaterialLocalizations? localizations = Localizations.of<MaterialLocalizations>(context, MaterialLocalizations); // <== 2
    final ScriptCategory category = localizations?.scriptCategory ?? ScriptCategory.englishLike;
    final ThemeData theme = inheritedTheme?.theme.data ?? _kFallbackTheme;
    return ThemeData.localize(theme, theme.typography.geometryThemeFor(category)); // <== 3
  }
```

https://github.com/flutter/flutter/blob/5c97543027f62bf73062db5e06b1b1b9d5636dd1/packages/flutter/lib/src/material/theme.dart#L107-L113