### PR TITLE
Add MasterDetailPage.bottomBar

### DIFF
--- a/lib/src/layouts/yaru_landscape_layout.dart
+++ b/lib/src/layouts/yaru_landscape_layout.dart
@@ -19,6 +19,7 @@ class YaruLandscapeLayout extends StatefulWidget {
     this.previousPaneWidth,
     this.onLeftPaneWidthChange,
     this.appBar,
+    this.bottomBar,
     required this.controller,
   });
 
@@ -29,6 +30,7 @@ class YaruLandscapeLayout extends StatefulWidget {
   final double? previousPaneWidth;
   final Function(double)? onLeftPaneWidthChange;
   final PreferredSizeWidget? appBar;
+  final Widget? bottomBar;
   final YaruPageController controller;
 
   @override
@@ -156,6 +158,7 @@ class _YaruLandscapeLayoutState extends State<YaruLandscapeLayout> {
           onTap: _onTap,
           builder: widget.tileBuilder,
         ),
+        bottomNavigationBar: widget.bottomBar,
       ),
     );
   }

--- a/lib/src/layouts/yaru_master_detail_page.dart
+++ b/lib/src/layouts/yaru_master_detail_page.dart
@@ -57,6 +57,7 @@ class YaruMasterDetailPage extends StatefulWidget {
     this.layoutDelegate =
         const YaruMasterFixedPaneDelegate(paneWidth: _kDefaultPaneWidth),
     this.appBar,
+    this.bottomBar,
     this.initialIndex,
     this.onSelected,
     this.controller,
@@ -83,6 +84,9 @@ class YaruMasterDetailPage extends StatefulWidget {
 
   /// An optional custom AppBar for the left pane.
   final PreferredSizeWidget? appBar;
+
+  /// An optional bottom bar for the left pane.
+  final Widget? bottomBar;
 
   /// An optional index of the initial page to show.
   final int? initialIndex;
@@ -139,6 +143,7 @@ class _YaruMasterDetailPageState extends State<YaruMasterDetailPage> {
             pageBuilder: widget.pageBuilder,
             onSelected: widget.onSelected,
             appBar: widget.appBar,
+            bottomBar: widget.bottomBar,
             controller: _controller,
           );
         } else {
@@ -150,6 +155,7 @@ class _YaruMasterDetailPageState extends State<YaruMasterDetailPage> {
             previousPaneWidth: _previousPaneWidth,
             onLeftPaneWidthChange: (width) => _previousPaneWidth = width,
             appBar: widget.appBar,
+            bottomBar: widget.bottomBar,
             controller: _controller,
           );
         }

--- a/lib/src/layouts/yaru_portrait_layout.dart
+++ b/lib/src/layouts/yaru_portrait_layout.dart
@@ -12,6 +12,7 @@ class YaruPortraitLayout extends StatefulWidget {
     required this.pageBuilder,
     this.onSelected,
     this.appBar,
+    this.bottomBar,
     required this.controller,
   });
 
@@ -20,6 +21,7 @@ class YaruPortraitLayout extends StatefulWidget {
   final ValueChanged<int>? onSelected;
 
   final PreferredSizeWidget? appBar;
+  final Widget? bottomBar;
 
   final YaruPageController controller;
 
@@ -99,6 +101,7 @@ class _YaruPortraitLayoutState extends State<YaruPortraitLayout> {
                   onTap: _onTap,
                   builder: widget.tileBuilder,
                 ),
+                bottomNavigationBar: widget.bottomBar,
               ),
             ),
             if (_selectedIndex != -1) page(_selectedIndex)


### PR DESCRIPTION
Allows inserting an arbitrary sticky item at the bottom of the master list, similar to the app bar at the top.

Close: #440