### PR TITLE
Add YaruNavigationPage.leading/trailing

### DIFF
--- a/lib/src/layouts/yaru_navigation_page.dart
+++ b/lib/src/layouts/yaru_navigation_page.dart
@@ -24,6 +24,8 @@ class YaruNavigationPage extends StatefulWidget {
     this.initialIndex,
     this.onSelected,
     this.controller,
+    this.leading,
+    this.trailing,
   })  : assert(initialIndex == null || controller == null),
         assert((length == null) != (controller == null));
 
@@ -47,6 +49,12 @@ class YaruNavigationPage extends StatefulWidget {
 
   /// An optional controller that can be used to navigate to a specific index.
   final YaruPageController? controller;
+
+  /// The leading widget in the rail that is placed above the destinations.
+  final Widget? leading;
+
+  /// The trailing widget in the rail that is placed below the destinations.
+  final Widget? trailing;
 
   @override
   State<YaruNavigationPage> createState() => _YaruNavigationPageState();
@@ -134,6 +142,8 @@ class _YaruNavigationPageState extends State<YaruNavigationPage> {
             onDestinationSelected: _onTap,
             length: _length,
             itemBuilder: widget.itemBuilder,
+            leading: widget.leading,
+            trailing: widget.trailing,
           ),
         ),
       ),

--- a/lib/src/layouts/yaru_navigation_rail.dart
+++ b/lib/src/layouts/yaru_navigation_rail.dart
@@ -10,6 +10,8 @@ class YaruNavigationRail extends StatelessWidget {
     required this.itemBuilder,
     required this.selectedIndex,
     required this.onDestinationSelected,
+    this.leading,
+    this.trailing,
   })  : assert(length >= 2),
         assert(
           selectedIndex == null ||
@@ -33,26 +35,37 @@ class YaruNavigationRail extends StatelessWidget {
   /// `setState` to rebuild the navigation rail with the new [selectedIndex].
   final ValueChanged<int>? onDestinationSelected;
 
+  /// The leading widget in the rail that is placed above the destinations.
+  final Widget? leading;
+
+  /// The trailing widget in the rail that is placed below the destinations.
+  final Widget? trailing;
+
   @override
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 5),
-      child: Column(
-        children: <Widget>[
-          for (int i = 0; i < length; i += 1)
-            YaruNavigationRailItemScope(
-              index: i,
-              selected: i == selectedIndex,
-              onTap: () => onDestinationSelected?.call(i),
-              child: Builder(
-                builder: (context) => itemBuilder(
-                  context,
-                  i,
-                  i == selectedIndex,
+      child: IntrinsicHeight(
+        child: Column(
+          children: <Widget>[
+            if (leading != null) leading!,
+            for (int i = 0; i < length; i += 1)
+              YaruNavigationRailItemScope(
+                index: i,
+                selected: i == selectedIndex,
+                onTap: () => onDestinationSelected?.call(i),
+                child: Builder(
+                  builder: (context) => itemBuilder(
+                    context,
+                    i,
+                    i == selectedIndex,
+                  ),
                 ),
               ),
-            )
-        ],
+            const Spacer(),
+            if (trailing != null) trailing!,
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
This is `YaruNavigationPage`'s counterpart to `YaruMasterDetailPage.bottomBar` (#441) but behaviorally different. Unlike master-detail, navigation rail's leading and trailing widgets are inside the scroll view.