### PR TITLE
YaruTitleBar: implement PreferredSizeWidget

### DIFF
--- a/lib/src/controls/yaru_title_bar.dart
+++ b/lib/src/controls/yaru_title_bar.dart
@@ -7,7 +7,7 @@ import 'yaru_close_button.dart';
 /// which pops the top-most route off the navigator
 /// that most tightly encloses the given context.
 ///
-class YaruTitleBar extends StatelessWidget {
+class YaruTitleBar extends StatelessWidget implements PreferredSizeWidget {
   const YaruTitleBar({
     super.key,
     this.leading,
@@ -31,6 +31,9 @@ class YaruTitleBar extends StatelessWidget {
 
   /// The background color. Defaults to [Colors.transparent].
   final Color? backgroundColor;
+
+  @override
+  Size get preferredSize => const Size(0, kYaruTitleBarHeight);
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
This allows using YaruTitleBar as Scaffold.appBar.

```dart
Scaffold(
  appBar: YaruTitleBar(),
  body: ...
)
```

> The argument type 'YaruTitleBar' can't be assigned to the parameter type 'PreferredSizeWidget?' .dart([argument_type_not_assignable](https://dart.dev/diagnostics/argument_type_not_assignable))

https://api.flutter.dev/flutter/material/Scaffold/appBar.html

## Pull request checklist

- [x] This PR does not introduce visual changes, **or**
  - I ran `flutter test --update-goldens` and committed the changes if there were any, **or**
  - I added before/after/light/dark screenshots if the visual changes I made were not covered by golden tests.
    | |Before|After|
    |-|-|-|
    |Light| | |
    |Dark| | |