### PR TITLE
YaruBanner: more sane default colors

### DIFF
--- a/lib/src/utilities/yaru_banner.dart
+++ b/lib/src/utilities/yaru_banner.dart
@@ -73,9 +73,9 @@ class YaruBanner extends StatelessWidget {
     final borderRadius = BorderRadius.circular(10);
 
     final light = theme.brightness == Brightness.light;
-    final defaultSurfaceTintColor = light
-        ? theme.colorScheme.background
-        : theme.colorScheme.onSurface.withOpacity(0.01);
+
+    final defaultSurfaceTintColor =
+        light ? theme.cardColor : const Color.fromARGB(255, 126, 126, 126);
     return Material(
       color: Colors.transparent,
       child: InkWell(
@@ -87,7 +87,7 @@ class YaruBanner extends StatelessWidget {
           color: color,
           shadowColor: Colors.transparent,
           surfaceTintColor: surfaceTintColor ?? defaultSurfaceTintColor,
-          elevation: elevation ?? (light ? 4 : 6),
+          elevation: elevation ?? 1,
           shape: RoundedRectangleBorder(
             borderRadius: borderRadius
                 .inner(const EdgeInsets.all(4.0)), // 4 is the default margin


### PR DESCRIPTION
Fixes #448

## Pull request checklist

- [x] This PR does not introduce visual changes, **or**
  - I ran `flutter test --update-goldens` and committed the changes if there were any, **or**
  - I added before/after/light/dark screenshots if the visual changes I made were not covered by golden tests.
    | |Before|After|
    |-|-|-|
    |Light|![grafik](https://user-images.githubusercontent.com/15329494/205498895-c48ad728-d053-49d0-beeb-f5c60e6a692f.png)|![grafik](https://user-images.githubusercontent.com/15329494/205498895-c48ad728-d053-49d0-beeb-f5c60e6a692f.png)|
    |Dark|![grafik](https://user-images.githubusercontent.com/15329494/205498944-7840f505-e4da-4b44-b50e-09a9ac1720df.png)| ![grafik](https://user-images.githubusercontent.com/15329494/205498868-518a478d-120a-458f-bc2e-e7b8f5c08b97.png)|

