### PR TITLE
MD: wrap detail page with ScaffoldMessenger in landscape layout

### DIFF
--- a/lib/src/layouts/yaru_landscape_layout.dart
+++ b/lib/src/layouts/yaru_landscape_layout.dart
@@ -186,17 +186,19 @@ class _YaruLandscapeLayoutState extends State<YaruLandscapeLayout> {
       data: Theme.of(context).copyWith(
         pageTransitionsTheme: theme.landscapeTransitions,
       ),
-      child: Navigator(
-        pages: [
-          MaterialPage(
-            key: ValueKey(_selectedIndex),
-            child: widget.controller.length > _selectedIndex
-                ? widget.pageBuilder(context, _selectedIndex)
-                : widget.pageBuilder(context, 0),
-          ),
-        ],
-        onPopPage: (route, result) => route.didPop(result),
-        observers: [HeroController()],
+      child: ScaffoldMessenger(
+        child: Navigator(
+          pages: [
+            MaterialPage(
+              key: ValueKey(_selectedIndex),
+              child: widget.controller.length > _selectedIndex
+                  ? widget.pageBuilder(context, _selectedIndex)
+                  : widget.pageBuilder(context, 0),
+            ),
+          ],
+          onPopPage: (route, result) => route.didPop(result),
+          observers: [HeroController()],
+        ),
       ),
     );
   }


### PR DESCRIPTION
This ensures that snackbars and banners are shown on the detail page.

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/140617/210116044-47be313e-899d-4b5b-a34c-bd977477224b.png) | ![image](https://user-images.githubusercontent.com/140617/210116063-0399e0ed-4fa9-4dd9-8782-cfb0551e7e09.png) |

Fixes: #447