### PR TITLE
YaruTitleBar: make themable and use window controls

### DIFF
--- a/lib/src/controls/yaru_title_bar.dart
+++ b/lib/src/controls/yaru_title_bar.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
 
 import '../constants.dart';
-import 'yaru_close_button.dart';
+import 'yaru_title_bar_theme.dart';
+import 'yaru_window_control.dart';
+
+const _kTitleButtonPadding = EdgeInsets.symmetric(horizontal: 7);
 
 /// A [Stack] of a [Widget] as [title] with a close button
 /// which pops the top-most route off the navigator
@@ -13,8 +16,20 @@ class YaruTitleBar extends StatelessWidget implements PreferredSizeWidget {
     this.leading,
     this.title,
     this.trailing,
-    this.centerTitle = true,
-    this.backgroundColor = Colors.transparent,
+    this.centerTitle,
+    this.foregroundColor,
+    this.backgroundColor,
+    this.isActive,
+    this.isClosable,
+    this.isMaximizable,
+    this.isRestorable,
+    this.isMinimizable,
+    this.onClose,
+    this.onMaximize,
+    this.onMinimize,
+    this.onMove,
+    this.onRestore,
+    this.onShowMenu,
   });
 
   /// The primary title widget.
@@ -29,32 +44,165 @@ class YaruTitleBar extends StatelessWidget implements PreferredSizeWidget {
   /// Whether the title should be centered.
   final bool? centerTitle;
 
-  /// The background color. Defaults to [Colors.transparent].
+  /// The foreground color.
+  final Color? foregroundColor;
+
+  /// The background color.
   final Color? backgroundColor;
+
+  /// Whether the title bar visualized as active.
+  final bool? isActive;
+
+  /// Whether the title bar shows a close button.
+  final bool? isClosable;
+
+  /// Whether the title bar shows a maximize button.
+  final bool? isMaximizable;
+
+  /// Whether the title bar shows a restore button.
+  final bool? isRestorable;
+
+  /// Whether the title bar shows a minimize button.
+  final bool? isMinimizable;
+
+  /// Called when the close button is pressed.
+  final void Function(BuildContext)? onClose;
+
+  /// Called when the maximize button is pressed or the title bar is
+  /// double-clicked while the window is not maximized.
+  final void Function(BuildContext)? onMaximize;
+
+  /// Called when the minimize button is pressed.
+  final void Function(BuildContext)? onMinimize;
+
+  /// Called when the title bar is drag to move the window.
+  final void Function(BuildContext)? onMove;
+
+  /// Called when the restore button is pressed or the title bar is
+  /// double-clicked while the window is maximized.
+  final void Function(BuildContext)? onRestore;
+
+  /// Called when the secondary mouse button is pressed.
+  final void Function(BuildContext)? onShowMenu;
 
   @override
   Size get preferredSize => const Size(0, kYaruTitleBarHeight);
 
   @override
   Widget build(BuildContext context) {
-    return AppBar(
-      elevation: 0,
-      leading: leading,
-      automaticallyImplyLeading: false,
-      title: title,
-      centerTitle: centerTitle,
-      toolbarHeight: kYaruTitleBarHeight,
-      backgroundColor: backgroundColor,
-      titleTextStyle: Theme.of(context).dialogTheme.titleTextStyle,
-      actions: [
-        Padding(
-          padding: const EdgeInsets.all(5),
-          child: Align(
-            alignment: Alignment.topRight,
-            child: trailing ?? const YaruCloseButton(),
+    final theme = YaruTitleBarTheme.of(context);
+    final light = Theme.of(context).brightness == Brightness.light;
+
+    final states = <MaterialState>{
+      if (isActive == true) MaterialState.focused,
+    };
+    final defaultBackgroundColor = MaterialStateProperty.resolveWith((states) {
+      if (!states.contains(MaterialState.focused)) {
+        return Colors.transparent;
+      }
+      return Colors.black.withOpacity(light ? 0.075 : 0.2);
+    });
+    final backgroundColor =
+        MaterialStateProperty.resolveAs(this.backgroundColor, states) ??
+            theme.backgroundColor?.resolve(states) ??
+            defaultBackgroundColor.resolve(states);
+    final foregroundColor =
+        MaterialStateProperty.resolveAs(this.foregroundColor, states) ??
+            theme.foregroundColor?.resolve(states) ??
+            Theme.of(context).colorScheme.onSurface;
+    final titleTextStyle =
+        theme.titleTextStyle?.copyWith(color: foregroundColor);
+    final shape = theme.shape ??
+        Border(
+          bottom: BorderSide(
+            color: Colors.black.withOpacity(light ? 0.1 : 0.2),
           ),
+        );
+
+    return GestureDetector(
+      behavior: HitTestBehavior.translucent,
+      onPanStart: (_) => onMove?.call(context),
+      onDoubleTap: () => isMaximizable == true
+          ? onMaximize?.call(context)
+          : isRestorable == true
+              ? onRestore?.call(context)
+              : null,
+      onSecondaryTap: onShowMenu != null ? () => onShowMenu!(context) : null,
+      child: AnimatedOpacity(
+        // TODO: backdrop effect
+        opacity: isActive == true ? 1 : 0.75,
+        duration: kThemeAnimationDuration,
+        child: AppBar(
+          elevation: theme.elevation,
+          leading: leading,
+          automaticallyImplyLeading: false,
+          title: title,
+          centerTitle: centerTitle ?? theme.centerTitle,
+          toolbarHeight: kYaruTitleBarHeight,
+          foregroundColor: foregroundColor,
+          backgroundColor: backgroundColor,
+          titleTextStyle: titleTextStyle,
+          shape: shape,
+          actions: [
+            Hero(
+              tag: '$this',
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  if (trailing != null)
+                    Padding(
+                      padding: _kTitleButtonPadding,
+                      child: Align(
+                        alignment: Alignment.topRight,
+                        child: trailing,
+                      ),
+                    ),
+                  const SizedBox(width: 3),
+                  if (isMinimizable == true)
+                    Padding(
+                      padding: _kTitleButtonPadding,
+                      child: YaruWindowControl(
+                        type: YaruWindowControlType.minimize,
+                        onTap: onMinimize != null
+                            ? () => onMinimize!(context)
+                            : null,
+                      ),
+                    ),
+                  if (isRestorable == true)
+                    Padding(
+                      padding: _kTitleButtonPadding,
+                      child: YaruWindowControl(
+                        type: YaruWindowControlType.restore,
+                        onTap: onRestore != null
+                            ? () => onRestore!(context)
+                            : null,
+                      ),
+                    ),
+                  if (isMaximizable == true)
+                    Padding(
+                      padding: _kTitleButtonPadding,
+                      child: YaruWindowControl(
+                        type: YaruWindowControlType.maximize,
+                        onTap: onMaximize != null
+                            ? () => onMaximize!(context)
+                            : null,
+                      ),
+                    ),
+                  if (isClosable == true)
+                    Padding(
+                      padding: _kTitleButtonPadding,
+                      child: YaruWindowControl(
+                        type: YaruWindowControlType.close,
+                        onTap: onClose != null ? () => onClose!(context) : null,
+                      ),
+                    ),
+                  const SizedBox(width: 3),
+                ],
+              ),
+            ),
+          ],
         ),
-      ],
+      ),
     );
   }
 }

--- a/lib/src/controls/yaru_title_bar_theme.dart
+++ b/lib/src/controls/yaru_title_bar_theme.dart
@@ -1,0 +1,142 @@
+import 'dart:ui';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+const _kTitleTextStyle = TextStyle(fontSize: 14, fontWeight: FontWeight.w500);
+
+@immutable
+class YaruTitleBarThemeData extends ThemeExtension<YaruTitleBarThemeData>
+    with Diagnosticable {
+  const YaruTitleBarThemeData({
+    this.elevation = 0,
+    this.centerTitle = true,
+    this.titleSpacing,
+    this.foregroundColor,
+    this.backgroundColor,
+    this.titleTextStyle = _kTitleTextStyle,
+    this.shape,
+  });
+
+  final double? elevation;
+  final bool? centerTitle;
+  final double? titleSpacing;
+  final MaterialStateProperty<Color?>? foregroundColor;
+  final MaterialStateProperty<Color?>? backgroundColor;
+  final TextStyle? titleTextStyle;
+  final ShapeBorder? shape;
+
+  @override
+  YaruTitleBarThemeData copyWith({
+    double? elevation,
+    bool? centerTitle,
+    double? titleSpacing,
+    MaterialStateProperty<Color?>? foregroundColor,
+    MaterialStateProperty<Color?>? backgroundColor,
+    TextStyle? titleTextStyle,
+    ShapeBorder? shape,
+  }) {
+    return YaruTitleBarThemeData(
+      elevation: elevation ?? this.elevation,
+      centerTitle: centerTitle ?? this.centerTitle,
+      titleSpacing: titleSpacing ?? this.titleSpacing,
+      foregroundColor: foregroundColor ?? this.foregroundColor,
+      backgroundColor: backgroundColor ?? this.backgroundColor,
+      titleTextStyle: titleTextStyle ?? this.titleTextStyle,
+      shape: shape ?? this.shape,
+    );
+  }
+
+  @override
+  ThemeExtension<YaruTitleBarThemeData> lerp(
+    ThemeExtension<YaruTitleBarThemeData>? other,
+    double t,
+  ) {
+    final o = other as YaruTitleBarThemeData?;
+    return YaruTitleBarThemeData(
+      elevation: lerpDouble(elevation, o?.elevation, t),
+      centerTitle: t < 0.5 ? centerTitle : o?.centerTitle,
+      titleSpacing: lerpDouble(titleSpacing, o?.titleSpacing, t),
+      foregroundColor: MaterialStateProperty.lerp<Color?>(
+        foregroundColor,
+        o?.foregroundColor,
+        t,
+        Color.lerp,
+      ),
+      backgroundColor: MaterialStateProperty.lerp<Color?>(
+        backgroundColor,
+        o?.backgroundColor,
+        t,
+        Color.lerp,
+      ),
+      titleTextStyle: TextStyle.lerp(titleTextStyle, o?.titleTextStyle, t),
+      shape: ShapeBorder.lerp(shape, o?.shape, t),
+    );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DoubleProperty('elevation', elevation));
+    properties.add(DiagnosticsProperty('centerTitle', centerTitle));
+    properties.add(DoubleProperty('titleSpacing', titleSpacing));
+    properties.add(DiagnosticsProperty('foregroundColor', foregroundColor));
+    properties.add(DiagnosticsProperty('backgroundColor', backgroundColor));
+    properties.add(DiagnosticsProperty('titleTextStyle', titleTextStyle));
+    properties.add(DiagnosticsProperty('shape', shape));
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is YaruTitleBarThemeData &&
+        other.elevation == elevation &&
+        other.centerTitle == centerTitle &&
+        other.titleSpacing == titleSpacing &&
+        other.foregroundColor == foregroundColor &&
+        other.backgroundColor == backgroundColor &&
+        other.titleTextStyle == titleTextStyle &&
+        other.shape == shape;
+  }
+
+  @override
+  int get hashCode {
+    return Object.hash(
+      elevation,
+      centerTitle,
+      titleSpacing,
+      foregroundColor,
+      backgroundColor,
+      titleTextStyle,
+      shape,
+    );
+  }
+}
+
+class YaruTitleBarTheme extends InheritedTheme {
+  const YaruTitleBarTheme({
+    super.key,
+    required this.data,
+    required super.child,
+  });
+
+  final YaruTitleBarThemeData data;
+
+  static YaruTitleBarThemeData of(BuildContext context) {
+    final theme =
+        context.dependOnInheritedWidgetOfExactType<YaruTitleBarTheme>();
+    return theme?.data ??
+        Theme.of(context).extension<YaruTitleBarThemeData>() ??
+        const YaruTitleBarThemeData();
+  }
+
+  @override
+  Widget wrap(BuildContext context, Widget child) {
+    return YaruTitleBarTheme(data: data, child: child);
+  }
+
+  @override
+  bool updateShouldNotify(YaruTitleBarTheme oldWidget) {
+    return data != oldWidget.data;
+  }
+}

--- a/lib/yaru_widgets.dart
+++ b/lib/yaru_widgets.dart
@@ -21,6 +21,7 @@ export 'src/controls/yaru_switch.dart';
 export 'src/controls/yaru_switch_button.dart';
 export 'src/controls/yaru_switch_list_tile.dart';
 export 'src/controls/yaru_title_bar.dart';
+export 'src/controls/yaru_title_bar_theme.dart';
 export 'src/controls/yaru_toggle_button.dart';
 export 'src/controls/yaru_toggle_button_theme.dart';
 export 'src/controls/yaru_window_control.dart';


### PR DESCRIPTION
Visual changes extracted from #455, leaving out any actual top-level window-related functionality i.e. `YaruWindowTitleBar`, `YaruDialogTitleBar`, and `YaruWindowController`.

NOTE: This is a breaking change. `YaruTitleBar` no longer creates a `YaruCloseButton` that calls `Navigator.pop`. Instead, it has a set of properties that can be used to manage which `YaruWindowControls` to create.

P.S. `YaruWindowTitleBar` and `YaruDialogTitleBar` are still coming but without `window_manager` dependency as originally proposed in #455. :)