### PR TITLE
MD: fix page controller updates

### DIFF
--- a/lib/src/layouts/yaru_landscape_layout.dart
+++ b/lib/src/layouts/yaru_landscape_layout.dart
@@ -70,6 +70,7 @@ class _YaruLandscapeLayoutState extends State<YaruLandscapeLayout> {
     if (widget.controller != oldWidget.controller) {
       oldWidget.controller.removeListener(_controllerCallback);
       widget.controller.addListener(_controllerCallback);
+      _selectedIndex = max(widget.controller.index, 0);
     }
   }
 

--- a/lib/src/layouts/yaru_master_detail_page.dart
+++ b/lib/src/layouts/yaru_master_detail_page.dart
@@ -103,15 +103,13 @@ class YaruMasterDetailPage extends StatefulWidget {
 
 class _YaruMasterDetailPageState extends State<YaruMasterDetailPage> {
   double? _previousPaneWidth;
-  late final YaruPageController _controller;
+  late YaruPageController _controller;
 
   void _updateController() => _controller = widget.controller ??
       YaruPageController(
-        length: _length,
+        length: widget.length ?? widget.controller!.length,
         initialIndex: widget.initialIndex ?? -1,
       );
-
-  int get _length => widget.length ?? widget.controller!.length;
 
   @override
   void initState() {
@@ -128,7 +126,11 @@ class _YaruMasterDetailPageState extends State<YaruMasterDetailPage> {
   @override
   void didUpdateWidget(covariant YaruMasterDetailPage oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.controller != oldWidget.controller) _updateController();
+    if (widget.controller != oldWidget.controller ||
+        widget.length != oldWidget.length ||
+        widget.initialIndex != oldWidget.initialIndex) {
+      _updateController();
+    }
   }
 
   @override

--- a/lib/src/layouts/yaru_portrait_layout.dart
+++ b/lib/src/layouts/yaru_portrait_layout.dart
@@ -54,6 +54,7 @@ class _YaruPortraitLayoutState extends State<YaruPortraitLayout> {
     if (widget.controller != oldWidget.controller) {
       oldWidget.controller.removeListener(_controllerCallback);
       widget.controller.addListener(_controllerCallback);
+      _selectedIndex = widget.controller.index;
     }
   }
 


### PR DESCRIPTION
`MasterDetailPage` can be rebuilt with either a) a different `controller`, or b) a different `length` and `initialIndex`. Make sure `didUpdateWidget` checks for both cases.

Ref: ubuntu-flutter-community/settings#421