### PR TITLE
Navigation/MD pages: pop all but first on select

### DIFF
--- a/lib/src/layouts/yaru_landscape_layout.dart
+++ b/lib/src/layouts/yaru_landscape_layout.dart
@@ -42,6 +42,7 @@ const _kLeftPaneResizingRegionAnimationDuration = Duration(milliseconds: 250);
 
 class _YaruLandscapeLayoutState extends State<YaruLandscapeLayout> {
   late int _selectedIndex;
+  final _navigatorKey = GlobalKey<NavigatorState>();
 
   double? _paneWidth;
   double? _initialPaneWidth;
@@ -83,6 +84,7 @@ class _YaruLandscapeLayoutState extends State<YaruLandscapeLayout> {
   void _onTap(int index) {
     widget.controller.index = index;
     widget.onSelected?.call(_selectedIndex);
+    _navigatorKey.currentState?.popUntil((route) => route.isFirst);
   }
 
   void updatePaneWidth({
@@ -189,6 +191,7 @@ class _YaruLandscapeLayoutState extends State<YaruLandscapeLayout> {
       ),
       child: ScaffoldMessenger(
         child: Navigator(
+          key: _navigatorKey,
           pages: [
             MaterialPage(
               key: ValueKey(_selectedIndex),

--- a/lib/src/layouts/yaru_navigation_page.dart
+++ b/lib/src/layouts/yaru_navigation_page.dart
@@ -63,6 +63,7 @@ class YaruNavigationPage extends StatefulWidget {
 class _YaruNavigationPageState extends State<YaruNavigationPage> {
   late final ScrollController _scrollController;
   late YaruPageController _pageController;
+  final _navigatorKey = GlobalKey<NavigatorState>();
 
   @override
   void initState() {
@@ -127,6 +128,7 @@ class _YaruNavigationPageState extends State<YaruNavigationPage> {
   void _onTap(int index) {
     _pageController.index = index;
     widget.onSelected?.call(index);
+    _navigatorKey.currentState?.popUntil((route) => route.isFirst);
   }
 
   Widget _buildNavigationRail(BuildContext context, BoxConstraints constraint) {
@@ -167,6 +169,7 @@ class _YaruNavigationPageState extends State<YaruNavigationPage> {
           pageTransitionsTheme: theme.pageTransitions,
         ),
         child: Navigator(
+          key: _navigatorKey,
           pages: [
             MaterialPage(
               key: ValueKey(index),


### PR DESCRIPTION
Clears the navigator stack of the right pane in `YaruLandScapeLayout` and `YaruNavigationPage` when (re-)selecting an entry in the left pane.

See https://github.com/ubuntu-flutter-community/software/issues/254

Edit: This requires us to use the navigator provided by the respective Yaru page, rather than nesting another one below.

## Pull request checklist

- [x] This PR does not introduce visual changes, **or**
  - I ran `flutter test --update-goldens` and committed the changes if there were any, **or**
  - I added before/after/light/dark screenshots if the visual changes I made were not covered by golden tests.
    | |Before|After|
    |-|-|-|
    |Light| | |
    |Dark| | |