### PR TITLE
Use new filled icons in sidebar navigation

### DIFF
--- a/example/lib/example_page_items.dart
+++ b/example/lib/example_page_items.dart
@@ -101,7 +101,9 @@ final examplePageItems = <PageItem>[
   PageItem(
     titleBuilder: (context) => const Text('NavigationPage'),
     tooltipMessage: 'YaruNavigationPage',
-    iconBuilder: (context, selected) => const Icon(YaruIcons.compass),
+    iconBuilder: (context, selected) => selected
+        ? const Icon(YaruIcons.compass_filled)
+        : const Icon(YaruIcons.compass),
     pageBuilder: (_) => const NavigationPage(),
   ),
   PageItem(
@@ -127,7 +129,9 @@ final examplePageItems = <PageItem>[
     tooltipMessage: 'YaruProgressIndicator',
     snippetUrl:
         'https://raw.githubusercontent.com/ubuntu/yaru_widgets.dart/main/example/lib/pages/progress_indicator_page.dart',
-    iconBuilder: (context, selected) => const Icon(YaruIcons.download),
+    iconBuilder: (context, selected) => selected
+        ? const Icon(YaruIcons.download_filled)
+        : const Icon(YaruIcons.download),
     pageBuilder: (_) => const ProgressIndicatorPage(),
   ),
   PageItem(
@@ -145,7 +149,9 @@ final examplePageItems = <PageItem>[
     tooltipMessage: 'YaruSection',
     snippetUrl:
         'https://raw.githubusercontent.com/ubuntu/yaru_widgets.dart/main/example/lib/pages/section_page.dart',
-    iconBuilder: (context, selected) => const Icon(YaruIcons.window),
+    iconBuilder: (context, selected) => selected
+        ? const Icon(YaruIcons.window_filled)
+        : const Icon(YaruIcons.window),
     pageBuilder: (_) => const SectionPage(),
   ),
   PageItem(
@@ -172,7 +178,9 @@ final examplePageItems = <PageItem>[
     snippetUrl:
         'https://raw.githubusercontent.com/ubuntu/yaru_widgets.dart/main/example/lib/pages/tabbed_page_page.dart',
     pageBuilder: (_) => const TabbedPagePage(),
-    iconBuilder: (context, selected) => const Icon(YaruIcons.tab_new),
+    iconBuilder: (context, selected) => selected
+        ? const Icon(YaruIcons.tab_new_filled)
+        : const Icon(YaruIcons.tab_new),
   ),
   PageItem(
     titleBuilder: (context) => const Text('YaruTile'),
@@ -195,7 +203,9 @@ final examplePageItems = <PageItem>[
   PageItem(
     titleBuilder: (context) => const Text('YaruWindowControl'),
     tooltipMessage: 'YaruWindowControl',
-    iconBuilder: (context, selected) => const Icon(YaruIcons.window_top_bar),
+    iconBuilder: (context, selected) => selected
+        ? const Icon(YaruIcons.window_top_bar_filled)
+        : const Icon(YaruIcons.window_top_bar),
     pageBuilder: (_) => const WindowControlsPage(),
   ),
 ];


### PR DESCRIPTION
I added a lot of new filled icons in yaru_icons, so let's use them in the navigation :)

https://user-images.githubusercontent.com/36476595/211783903-4bf45893-7a53-423a-877c-9eb722e20ab7.mp4


## Pull request checklist

- [x] This PR does not introduce visual changes