### PR TITLE
Fix stretched yaru togglables

### DIFF
--- a/lib/src/controls/yaru_togglable.dart
+++ b/lib/src/controls/yaru_togglable.dart
@@ -250,33 +250,38 @@ abstract class YaruTogglableState<S extends YaruTogglable> extends State<S>
 
     return _buildSemantics(
       child: _buildEventDetectors(
-        child: SizedBox(
-          width: togglableSize.width + activableAreaPadding.horizontal,
-          height: togglableSize.height + activableAreaPadding.vertical,
-          child: Padding(
-            padding: activableAreaPadding,
-            child: CustomPaint(
-              size: togglableSize,
-              painter: painter
-                ..interactive = widget.interactive
-                ..hover = _hover
-                ..focus = _focus
-                ..active = _active
-                ..checked = widget.checked
-                ..oldChecked = _oldChecked
-                ..position = _position
-                ..sizePosition = _sizePosition
-                ..indicatorPosition = _indicatorPosition
-                ..uncheckedColor = uncheckedColor
-                ..uncheckedBorderColor = uncheckedBorderColor
-                ..checkedColor = checkedColor
-                ..checkmarkColor = checkmarkColor
-                ..disabledUncheckedColor = uncheckedDisabledColor
-                ..disabledUncheckedBorderColor = uncheckedDisabledBorderColor
-                ..disabledCheckedColor = checkedDisabledColor
-                ..disabledCheckmarkColor = checkmarkDisabledColor
-                ..hoverIndicatorColor = hoverIndicatorColor
-                ..focusIndicatorColor = focusIndicatorColor,
+        child: Padding(
+          padding: activableAreaPadding,
+          child: SizedBox(
+            width: togglableSize.width,
+            height: togglableSize.height,
+            child: Center(
+              child: RepaintBoundary(
+                child: CustomPaint(
+                  size: togglableSize,
+                  painter: painter
+                    ..interactive = widget.interactive
+                    ..hover = _hover
+                    ..focus = _focus
+                    ..active = _active
+                    ..checked = widget.checked
+                    ..oldChecked = _oldChecked
+                    ..position = _position
+                    ..sizePosition = _sizePosition
+                    ..indicatorPosition = _indicatorPosition
+                    ..uncheckedColor = uncheckedColor
+                    ..uncheckedBorderColor = uncheckedBorderColor
+                    ..checkedColor = checkedColor
+                    ..checkmarkColor = checkmarkColor
+                    ..disabledUncheckedColor = uncheckedDisabledColor
+                    ..disabledUncheckedBorderColor =
+                        uncheckedDisabledBorderColor
+                    ..disabledCheckedColor = checkedDisabledColor
+                    ..disabledCheckmarkColor = checkmarkDisabledColor
+                    ..hoverIndicatorColor = hoverIndicatorColor
+                    ..focusIndicatorColor = focusIndicatorColor,
+                ),
+              ),
             ),
           ),
         ),


### PR DESCRIPTION
- Center the painter to fix the stretch effect ;
- Add `RepaintBoundary` widget around the painter to keep a sharp look ;
- Correct weird logic of putting a `Padding` in a `SizedBox`, which was require to add up padding value to the dimensions.

@jpnurmi as you can see, I'm now using a personal fork ;)

**Before:**

![Capture d’écran du 2023-01-11 11-24-23](https://user-images.githubusercontent.com/36476595/211784220-0a458458-759f-4226-ac3f-4cc62cfe5256.png)

**After:**

![Capture d’écran du 2023-01-11 11-19-47](https://user-images.githubusercontent.com/36476595/211784231-31e86440-d256-4204-831a-632b457ca2db.png)

## Pull request checklist

- [x] This PR does not introduce visual changes

Fixes #484 