### PR TITLE
CI: add missing apt update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: subosito/flutter-action@v1
         with:
           channel: "stable"
+      - run: sudo apt update
       - run: sudo apt -y install git curl cmake ninja-build make clang libgtk-3-dev pkg-config
       - run: flutter pub get
       - run: flutter build linux -v


### PR DESCRIPTION
Build jobs have started failing with errors like:
```
Fetched 11.0 MB in 7s (1537 kB/s)
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/m/mesa/libegl-mesa0_22.0.5-0ubuntu0.1_amd64.deb  404  Not Found [IP: 40.119.46.219 80]
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/m/mesa/libegl1-mesa-dev_22.0.5-0ubuntu0.1_amd64.deb  404  Not Found [IP: 40.119.46.219 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Error: Process completed with exit code 100.
```
- https://github.com/ubuntu/yaru_widgets.dart/actions/runs/3891996009/jobs/6643045813
- https://github.com/ubuntu/yaru_widgets.dart/actions/runs/3891936309/jobs/6643042784
- https://github.com/ubuntu/yaru_widgets.dart/actions/runs/3892061928/jobs/6643034087
- ...