### PR TITLE
Hide `kTogglableActiveResizeFactor` out of the public API

### DIFF
--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -22,10 +22,6 @@ const kYaruButtonRadius = 6.0;
 /// between portrait and landscape modes.
 const kYaruMasterDetailBreakpoint = 620.0;
 
-// Used by tooglable widgets to resize the canvas on active state
-// Need to be an even number
-const kTogglableActiveResizeFactor = 2;
-
 const kCheckradioActivableAreaPadding = EdgeInsets.all(6);
 
 const kCheckradioTogglableSize = Size.square(20);

--- a/lib/src/controls/yaru_togglable.dart
+++ b/lib/src/controls/yaru_togglable.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 
-import '../constants.dart';
 import 'yaru_checkbox.dart';
 import 'yaru_radio.dart';
 import 'yaru_switch.dart';
@@ -9,6 +8,8 @@ const _kTogglableAnimationDuration = Duration(milliseconds: 150);
 const _kTogglableSizeAnimationDuration = Duration(milliseconds: 100);
 const _kIndicatorAnimationDuration = Duration(milliseconds: 200);
 const _kIndicatorRadius = 20.0;
+// Used to resize the canvas on active state. Must be an even number.
+const _kTogglableActiveResizeFactor = 2;
 
 /// A generic class to create a togglable widget
 ///
@@ -366,12 +367,12 @@ abstract class YaruTogglablePainter extends ChangeNotifier
     final canvasSize = size;
     final t = position.value;
     final drawingOrigin = Offset(
-      kTogglableActiveResizeFactor / 2 * sizePosition.value,
-      kTogglableActiveResizeFactor / 2 * sizePosition.value,
+      _kTogglableActiveResizeFactor / 2 * sizePosition.value,
+      _kTogglableActiveResizeFactor / 2 * sizePosition.value,
     );
     final drawingSize = Size(
-      canvasSize.width - kTogglableActiveResizeFactor * sizePosition.value,
-      canvasSize.height - kTogglableActiveResizeFactor * sizePosition.value,
+      canvasSize.width - _kTogglableActiveResizeFactor * sizePosition.value,
+      canvasSize.height - _kTogglableActiveResizeFactor * sizePosition.value,
     );
 
     paintTogglable(canvas, size, drawingSize, drawingOrigin, t);


### PR DESCRIPTION
@Jupi007 is this ok to hide? do we need it in the public `constants.dart`? it's only used in `togglable.dart`.

Ref: #489 
