### PR TITLE
YaruTitleBar: remove empty padding when there are no window controls

### DIFF
--- a/lib/src/controls/yaru_title_bar.dart
+++ b/lib/src/controls/yaru_title_bar.dart
@@ -189,41 +189,45 @@ class YaruTitleBar extends StatelessWidget implements PreferredSizeWidget {
                 mainAxisSize: MainAxisSize.min,
                 children: [
                   if (trailing != null) trailing!,
-                  Padding(
-                    padding: buttonPadding,
-                    child: Row(
-                      children: [
-                        if (isMinimizable == true)
-                          YaruWindowControl(
-                            type: YaruWindowControlType.minimize,
-                            onTap: onMinimize != null
-                                ? () => onMinimize!(context)
-                                : null,
-                          ),
-                        if (isRestorable == true)
-                          YaruWindowControl(
-                            type: YaruWindowControlType.restore,
-                            onTap: onRestore != null
-                                ? () => onRestore!(context)
-                                : null,
-                          ),
-                        if (isMaximizable == true)
-                          YaruWindowControl(
-                            type: YaruWindowControlType.maximize,
-                            onTap: onMaximize != null
-                                ? () => onMaximize!(context)
-                                : null,
-                          ),
-                        if (isClosable == true)
-                          YaruWindowControl(
-                            type: YaruWindowControlType.close,
-                            onTap: onClose != null
-                                ? () => onClose!(context)
-                                : null,
-                          ),
-                      ].withSpacing(buttonSpacing),
+                  if (isMinimizable == true ||
+                      isRestorable == true ||
+                      isMaximizable == true ||
+                      isClosable == true)
+                    Padding(
+                      padding: buttonPadding,
+                      child: Row(
+                        children: [
+                          if (isMinimizable == true)
+                            YaruWindowControl(
+                              type: YaruWindowControlType.minimize,
+                              onTap: onMinimize != null
+                                  ? () => onMinimize!(context)
+                                  : null,
+                            ),
+                          if (isRestorable == true)
+                            YaruWindowControl(
+                              type: YaruWindowControlType.restore,
+                              onTap: onRestore != null
+                                  ? () => onRestore!(context)
+                                  : null,
+                            ),
+                          if (isMaximizable == true)
+                            YaruWindowControl(
+                              type: YaruWindowControlType.maximize,
+                              onTap: onMaximize != null
+                                  ? () => onMaximize!(context)
+                                  : null,
+                            ),
+                          if (isClosable == true)
+                            YaruWindowControl(
+                              type: YaruWindowControlType.close,
+                              onTap: onClose != null
+                                  ? () => onClose!(context)
+                                  : null,
+                            ),
+                        ].withSpacing(buttonSpacing),
+                      ),
                     ),
-                  ),
                 ],
               ),
             )!,


### PR DESCRIPTION
If you remove all buttons and set title spacing to 0, you can have a container that provides the correct title bar background color that not only depends on the theme brightness but also whether the window is active. This could be useful as a background for the search field in the settings app.