### PR TITLE
YaruDetailPage: fix app/title bar height

### DIFF
--- a/lib/src/layouts/yaru_detail_page.dart
+++ b/lib/src/layouts/yaru_detail_page.dart
@@ -61,10 +61,7 @@ class YaruDetailPage extends StatelessWidget {
     if (appBar == null) return null;
 
     return PreferredSize(
-      preferredSize: Size(
-        0,
-        Theme.of(context).appBarTheme.toolbarHeight ?? kToolbarHeight,
-      ),
+      preferredSize: appBar!.preferredSize,
       child: Hero(
         tag: '<YaruDetailPage Hero tag - $appBar>',
         child: appBar!,


### PR DESCRIPTION
Use the height of the app/title bar that is passed in instead of forcing `AppBarTheme.toolbarHeight` which does currently not match with `kYaruTitleBarHeight`. Perhaps they should, though?

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/140617/212022296-8621454c-a8f8-4343-b3c4-3f98e6e5944a.png) | ![Screenshot from 2023-01-12 09-52-20](https://user-images.githubusercontent.com/140617/212022049-d83998ed-3c72-467a-9310-0173f126e1bc.png) |