### PR TITLE
YaruWindowTitleBar: fix slow window state init

### DIFF
--- a/lib/src/controls/yaru_title_bar.dart
+++ b/lib/src/controls/yaru_title_bar.dart
@@ -352,14 +352,15 @@ class YaruWindowTitleBar extends StatelessWidget
   @override
   Widget build(BuildContext context) {
     if (isVisible == false) return const SizedBox.shrink();
+    final windowState = YaruWindow.state(context);
     return StreamBuilder<YaruWindowState>(
-      stream: YaruWindow.states(),
+      stream: YaruWindow.states(context),
       initialData: YaruWindowState(
-        isActive: isActive,
-        isClosable: isClosable,
-        isMaximizable: isMaximizable,
-        isMinimizable: isMinimizable,
-        isRestorable: isRestorable,
+        isActive: isActive ?? windowState?.isActive,
+        isClosable: isClosable ?? windowState?.isClosable,
+        isMaximizable: isMaximizable ?? windowState?.isMaximizable,
+        isMinimizable: isMinimizable ?? windowState?.isMinimizable,
+        isRestorable: isRestorable ?? windowState?.isRestorable,
       ),
       builder: (context, snapshot) {
         final window = snapshot.data;


### PR DESCRIPTION
The window controls are no longer disappearing and re-appearing with a delay.

[Screencast from 2023-01-12 19-50-17.webm](https://user-images.githubusercontent.com/140617/212154623-b2c3426a-3312-4282-be36-e05b3d58ba77.webm)

Fixes: #505 