### PR TITLE
YaruWindowTitleBar: fix state init

### DIFF
--- a/lib/src/controls/yaru_title_bar.dart
+++ b/lib/src/controls/yaru_title_bar.dart
@@ -352,33 +352,33 @@ class YaruWindowTitleBar extends StatelessWidget
   @override
   Widget build(BuildContext context) {
     if (isVisible == false) return const SizedBox.shrink();
-    final windowState = YaruWindow.state(context);
+    final defaultState = YaruWindowState(
+      isActive: isActive,
+      isClosable: isClosable,
+      isMaximizable: isMaximizable,
+      isMinimizable: isMinimizable,
+      isRestorable: isRestorable,
+    );
     return StreamBuilder<YaruWindowState>(
       stream: YaruWindow.states(context),
-      initialData: YaruWindowState(
-        isActive: isActive ?? windowState?.isActive,
-        isClosable: isClosable ?? windowState?.isClosable,
-        isMaximizable: isMaximizable ?? windowState?.isMaximizable,
-        isMinimizable: isMinimizable ?? windowState?.isMinimizable,
-        isRestorable: isRestorable ?? windowState?.isRestorable,
-      ),
+      initialData: YaruWindow.state(context),
       builder: (context, snapshot) {
-        final window = snapshot.data;
+        final state = snapshot.data?.merge(defaultState) ?? defaultState;
         return YaruTitleBar(
           leading: leading,
-          title: title ?? Text(window?.title ?? ''),
+          title: title ?? Text(state.title ?? ''),
           trailing: trailing,
           centerTitle: centerTitle,
           titleSpacing: titleSpacing,
           backgroundColor: backgroundColor,
           shape: shape,
           border: border,
-          isActive: isActive ?? window?.isActive,
-          isClosable: isClosable ?? window?.isClosable,
-          isDraggable: isDraggable ?? window?.isMovable,
-          isMaximizable: isMaximizable ?? window?.isMaximizable,
-          isMinimizable: isMinimizable ?? window?.isMinimizable,
-          isRestorable: isRestorable ?? window?.isRestorable,
+          isActive: state.isActive,
+          isClosable: state.isClosable,
+          isDraggable: state.isMovable,
+          isMaximizable: state.isMaximizable,
+          isMinimizable: state.isMinimizable,
+          isRestorable: state.isRestorable,
           onClose: onClose,
           onDrag: onDrag,
           onMaximize: onMaximize,

--- a/lib/src/controls/yaru_window.dart
+++ b/lib/src/controls/yaru_window.dart
@@ -138,12 +138,16 @@ class YaruWindowListener implements WindowListener {
 
   YaruWindowState? get state => _state;
 
-  Stream<YaruWindowState> states() {
+  Stream<YaruWindowState> states() async* {
     _controller ??= StreamController<YaruWindowState>.broadcast(
       onListen: () => _wm.addListener(this),
       onCancel: () => _wm.removeListener(this),
     );
-    return _controller!.stream;
+    if (_state == null) {
+      _state = await _wm.state();
+      yield _state!;
+    }
+    yield* _controller!.stream;
   }
 
   Future<void> close() async => await _controller?.close();
@@ -208,6 +212,47 @@ class YaruWindowState {
   final bool? isMovable;
   final bool? isRestorable;
   final String? title;
+
+  YaruWindowState copyWith({
+    bool? isActive,
+    bool? isClosable,
+    bool? isFullscreen,
+    bool? isMaximizable,
+    bool? isMaximized,
+    bool? isMinimizable,
+    bool? isMinimized,
+    bool? isMovable,
+    bool? isRestorable,
+    String? title,
+  }) {
+    return YaruWindowState(
+      isActive: isActive ?? this.isActive,
+      isClosable: isClosable ?? this.isClosable,
+      isFullscreen: isFullscreen ?? this.isFullscreen,
+      isMaximizable: isMaximizable ?? this.isMaximizable,
+      isMaximized: isMaximized ?? this.isMaximized,
+      isMinimizable: isMinimizable ?? this.isMinimizable,
+      isMinimized: isMinimized ?? this.isMinimized,
+      isMovable: isMovable ?? this.isMovable,
+      isRestorable: isRestorable ?? this.isRestorable,
+      title: title ?? this.title,
+    );
+  }
+
+  YaruWindowState merge(YaruWindowState? other) {
+    return copyWith(
+      isActive: other?.isActive,
+      isClosable: other?.isClosable,
+      isFullscreen: other?.isFullscreen,
+      isMaximizable: other?.isMaximizable,
+      isMaximized: other?.isMaximized,
+      isMinimizable: other?.isMinimizable,
+      isMinimized: other?.isMinimized,
+      isMovable: other?.isMovable,
+      isRestorable: other?.isRestorable,
+      title: other?.title,
+    );
+  }
 
   @override
   bool operator ==(Object other) {

--- a/test/controls/yaru_title_bar_test.dart
+++ b/test/controls/yaru_title_bar_test.dart
@@ -14,7 +14,7 @@ void main() {
       final state = variant.value!;
       final builder = variant.label.contains('dialog')
           ? YaruDialogTitleBar.new
-          : YaruWindowTitleBar.new;
+          : YaruTitleBar.new;
 
       await tester.pumpScaffold(
         builder(
@@ -25,6 +25,10 @@ void main() {
           isMinimizable: state.isMinimizable,
           isRestorable: state.isRestorable,
           title: Text(state.title!),
+          onClose: (_) {},
+          onMaximize: (_) {},
+          onMinimize: (_) {},
+          onRestore: (_) {},
           backgroundColor: variant.label.contains('red') ? Colors.red : null,
         ),
         themeMode: variant.themeMode,


### PR DESCRIPTION
This fixes a regression introduced by #506 that e.g. the settings dialog title bar in the example is not draggable.