### PR TITLE
YaruTitleBar: fix hero conflict

### DIFF
--- a/lib/src/controls/yaru_title_bar.dart
+++ b/lib/src/controls/yaru_title_bar.dart
@@ -161,6 +161,18 @@ class YaruTitleBar extends StatelessWidget implements PreferredSizeWidget {
       );
     }
 
+    Widget maybeHero({
+      required Widget child,
+    }) {
+      if (context.findAncestorWidgetOfExactType<Hero>() != null) {
+        return child;
+      }
+      return Hero(
+        tag: '<YaruTitleBar $this>',
+        child: child,
+      );
+    }
+
     return GestureDetector(
       behavior: HitTestBehavior.translucent,
       onPanStart: isDraggable == true ? (_) => onDrag?.call(context) : null,
@@ -183,8 +195,7 @@ class YaruTitleBar extends StatelessWidget implements PreferredSizeWidget {
         titleTextStyle: titleTextStyle,
         shape: shape,
         actions: [
-          Hero(
-            tag: '$this',
+          maybeHero(
             child: backdropEffect(
               Row(
                 mainAxisSize: MainAxisSize.min,


### PR DESCRIPTION
This makes it possible to use `YaruTitleBar` in a `YaruDetailPage` that uses a unique hero tag to keep the whole app/title bar in place during page transitions. The inner title bar cannot contain another hero tag because heroes must not be nested.

Close: #503