### PR TITLE
Example: use CSD with yaruwindowtitlebar if not web

### DIFF
--- a/example/lib/example.dart
+++ b/example/lib/example.dart
@@ -1,4 +1,5 @@
 import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
@@ -50,18 +51,16 @@ class _ExampleState extends State<Example> {
               title: buildTitle(context, pageItems[index]),
             ),
             pageBuilder: (context, index) => YaruDetailPage(
-              appBar: AppBar(
-                leading: Navigator.of(context).canPop()
-                    ? const YaruBackButton()
-                    : null,
-                title: buildTitle(context, pageItems[index]),
-                actions: [CodeSnippedButton(pageItem: pageItems[index])],
-              ),
+              appBar: _appBar(context, pageItems, index),
               body: pageItems[index].pageBuilder(context),
             ),
-            appBar: AppBar(
-              title: const Text('Example'),
-            ),
+            appBar: kIsWeb
+                ? AppBar(
+                    title: const Text('Example'),
+                  )
+                : const YaruWindowTitleBar(
+                    title: Text('Example'),
+                  ),
             bottomBar: BottomAppBar(
               elevation: 0,
               child: Column(
@@ -80,6 +79,30 @@ class _ExampleState extends State<Example> {
               ),
             ),
           );
+  }
+
+  PreferredSizeWidget _appBar(
+    BuildContext context,
+    List<PageItem> pageItems,
+    int index,
+  ) {
+    final leading =
+        Navigator.of(context).canPop() ? const YaruBackButton() : null;
+    final title = buildTitle(context, pageItems[index]);
+    final trailing = CodeSnippedButton(pageItem: pageItems[index]);
+    if (kIsWeb) {
+      return AppBar(
+        leading: leading,
+        title: title,
+        actions: [trailing],
+      );
+    } else {
+      return YaruWindowTitleBar(
+        title: title,
+        leading: leading,
+        trailing: trailing,
+      );
+    }
   }
 }
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:yaru/yaru.dart';
@@ -29,14 +30,15 @@ class Home extends StatelessWidget {
       ),
       builder: (context, yaru, child) {
         return MaterialApp(
-          title: 'Yaru Widgets Factory',
           debugShowCheckedModeBanner: false,
           theme: yaru.theme,
           darkTheme: yaru.darkTheme,
-          home: Scaffold(
-            appBar: const YaruWindowTitleBar(),
-            body: Example.create(context),
-          ),
+          home: kIsWeb
+              ? Scaffold(
+                  appBar: const YaruWindowTitleBar(),
+                  body: Example.create(context),
+                )
+              : Example.create(context),
         );
       },
     );


### PR DESCRIPTION
Example

Desktop
![grafik](https://user-images.githubusercontent.com/15329494/212422283-fe0d47f0-3116-4d74-9691-cfdfff9cbca0.png)

Web
![grafik](https://user-images.githubusercontent.com/15329494/212422492-2575d9ea-9e87-4bbf-aeed-0fb6113ad124.png)


## Pull request checklist

- [X] This PR does not introduce visual changes, **or**
  - I ran `flutter test --update-goldens` and committed the changes if there were any, **or**
  - I added before/after/light/dark screenshots if the visual changes I made were not covered by golden tests.
    | |Before|After|
    |-|-|-|
    |Light| | |
    |Dark| | |