### PR TITLE
YaruWindowTitleBar: improve defaults for web

### DIFF
--- a/lib/src/controls/yaru_title_bar.dart
+++ b/lib/src/controls/yaru_title_bar.dart
@@ -109,7 +109,8 @@ class YaruTitleBar extends StatelessWidget implements PreferredSizeWidget {
   final FutureOr<void> Function(BuildContext)? onShowMenu;
 
   @override
-  Size get preferredSize => const Size(0, kYaruTitleBarHeight);
+  Size get preferredSize =>
+      Size(0, style == YaruTitleBarStyle.hidden ? 0 : kYaruTitleBarHeight);
 
   @override
   Widget build(BuildContext context) {
@@ -363,7 +364,8 @@ class YaruWindowTitleBar extends StatelessWidget
   final FutureOr<void> Function(BuildContext)? onShowMenu;
 
   @override
-  Size get preferredSize => const Size(0, kIsWeb ? 0 : kYaruTitleBarHeight);
+  Size get preferredSize =>
+      Size(0, style == YaruTitleBarStyle.hidden ? 0 : kYaruTitleBarHeight);
 
   static Future<void> ensureInitialized() => YaruWindow.ensureInitialized();
 
@@ -372,7 +374,7 @@ class YaruWindowTitleBar extends StatelessWidget
     final theme = YaruTitleBarTheme.of(context);
     final style = this.style ??
         theme.style ??
-        (kIsWeb ? YaruTitleBarStyle.hidden : YaruTitleBarStyle.normal);
+        (kIsWeb ? YaruTitleBarStyle.undecorated : YaruTitleBarStyle.normal);
     if (style == YaruTitleBarStyle.hidden) return const SizedBox.shrink();
 
     final defaultState = YaruWindowState(

--- a/lib/src/layouts/yaru_portrait_layout.dart
+++ b/lib/src/layouts/yaru_portrait_layout.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import '../controls/yaru_title_bar_theme.dart';
@@ -97,7 +98,9 @@ class _YaruPortraitLayoutState extends State<YaruPortraitLayout> {
             MaterialPage(
               child: YaruTitleBarTheme(
                 data: const YaruTitleBarThemeData(
-                  style: YaruTitleBarStyle.normal,
+                  style: kIsWeb
+                      ? YaruTitleBarStyle.undecorated
+                      : YaruTitleBarStyle.normal,
                 ),
                 child: Scaffold(
                   appBar: widget.appBar,


### PR DESCRIPTION
Now that we have the "undecorated" style, we can use that on web so YaruWindowTitleBar becomes a drop-in replacement for AppBar.