### PR TITLE
Example: move code snippet button out of the app bar

### DIFF
--- a/example/lib/code_snippet_button.dart
+++ b/example/lib/code_snippet_button.dart
@@ -35,6 +35,9 @@ class CodeSnippedButton extends StatelessWidget {
       ),
       child: const Icon(YaruIcons.code),
       tooltip: 'Example snippet',
+      foregroundColor: Theme.of(context).colorScheme.onSurface,
+      backgroundColor: PopupMenuTheme.of(context).color,
+      shape: PopupMenuTheme.of(context).shape,
     );
   }
 }

--- a/example/lib/code_snippet_button.dart
+++ b/example/lib/code_snippet_button.dart
@@ -18,28 +18,23 @@ class CodeSnippedButton extends StatelessWidget {
   Widget build(BuildContext context) {
     final model = context.watch<ExampleModel>();
     if (pageItem.snippetUrl == null) {
-      return Container();
+      return const SizedBox.shrink();
     }
-    return Padding(
-      padding: const EdgeInsets.only(right: 8),
-      child: Center(
-        child: YaruIconButton(
-          onPressed: () => showDialog(
-            barrierDismissible: true,
-            context: context,
-            builder: (context) {
-              return ChangeNotifierProvider.value(
-                value: model,
-                child: _CodeDialog(
-                  pageItem: pageItem,
-                ),
-              );
-            },
-          ),
-          icon: const Icon(YaruIcons.code),
-          tooltip: 'Example snippet',
-        ),
+    return FloatingActionButton(
+      onPressed: () => showDialog(
+        barrierDismissible: true,
+        context: context,
+        builder: (context) {
+          return ChangeNotifierProvider.value(
+            value: model,
+            child: _CodeDialog(
+              pageItem: pageItem,
+            ),
+          );
+        },
       ),
+      child: const Icon(YaruIcons.code),
+      tooltip: 'Example snippet',
     );
   }
 }

--- a/example/lib/example.dart
+++ b/example/lib/example.dart
@@ -55,9 +55,11 @@ class _ExampleState extends State<Example> {
                     ? const YaruBackButton()
                     : null,
                 title: buildTitle(context, pageItems[index]),
-                actions: [CodeSnippedButton(pageItem: pageItems[index])],
               ),
               body: pageItems[index].pageBuilder(context),
+              floatingActionButton: CodeSnippedButton(
+                pageItem: pageItems[index],
+              ),
             ),
             appBar: AppBar(
               title: const Text('Example'),
@@ -105,7 +107,12 @@ class _CompactPage extends StatelessWidget {
         tooltip: pageItems[index].title,
         style: style,
       ),
-      pageBuilder: (context, index) => pageItems[index].pageBuilder(context),
+      pageBuilder: (context, index) => Scaffold(
+        body: pageItems[index].pageBuilder(context),
+        floatingActionButton: CodeSnippedButton(
+          pageItem: pageItems[index],
+        ),
+      ),
       trailing: YaruNavigationRailItem(
         icon: const Icon(YaruIcons.gear),
         label: const Text('Settings'),


### PR DESCRIPTION
It takes too much space when we switch to a window title bar. How about using a FAB instead?

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/140617/212483338-a545dd09-5a3a-4e3f-baa2-d6136195a433.png) | ![Screenshot from 2023-01-14 17-25-26](https://user-images.githubusercontent.com/140617/212483282-e2098d9d-3d47-43a1-b155-27bba715ca5d.png) |
