### PR TITLE
Remove all RepaintBoundary widgets

### DIFF
--- a/lib/src/controls/yaru_togglable.dart
+++ b/lib/src/controls/yaru_togglable.dart
@@ -257,31 +257,28 @@ abstract class YaruTogglableState<S extends YaruTogglable> extends State<S>
             width: togglableSize.width,
             height: togglableSize.height,
             child: Center(
-              child: RepaintBoundary(
-                child: CustomPaint(
-                  size: togglableSize,
-                  painter: painter
-                    ..interactive = widget.interactive
-                    ..hover = _hover
-                    ..focus = _focus
-                    ..active = _active
-                    ..checked = widget.checked
-                    ..oldChecked = _oldChecked
-                    ..position = _position
-                    ..sizePosition = _sizePosition
-                    ..indicatorPosition = _indicatorPosition
-                    ..uncheckedColor = uncheckedColor
-                    ..uncheckedBorderColor = uncheckedBorderColor
-                    ..checkedColor = checkedColor
-                    ..checkmarkColor = checkmarkColor
-                    ..disabledUncheckedColor = uncheckedDisabledColor
-                    ..disabledUncheckedBorderColor =
-                        uncheckedDisabledBorderColor
-                    ..disabledCheckedColor = checkedDisabledColor
-                    ..disabledCheckmarkColor = checkmarkDisabledColor
-                    ..hoverIndicatorColor = hoverIndicatorColor
-                    ..focusIndicatorColor = focusIndicatorColor,
-                ),
+              child: CustomPaint(
+                size: togglableSize,
+                painter: painter
+                  ..interactive = widget.interactive
+                  ..hover = _hover
+                  ..focus = _focus
+                  ..active = _active
+                  ..checked = widget.checked
+                  ..oldChecked = _oldChecked
+                  ..position = _position
+                  ..sizePosition = _sizePosition
+                  ..indicatorPosition = _indicatorPosition
+                  ..uncheckedColor = uncheckedColor
+                  ..uncheckedBorderColor = uncheckedBorderColor
+                  ..checkedColor = checkedColor
+                  ..checkmarkColor = checkmarkColor
+                  ..disabledUncheckedColor = uncheckedDisabledColor
+                  ..disabledUncheckedBorderColor = uncheckedDisabledBorderColor
+                  ..disabledCheckedColor = checkedDisabledColor
+                  ..disabledCheckmarkColor = checkmarkDisabledColor
+                  ..hoverIndicatorColor = hoverIndicatorColor
+                  ..focusIndicatorColor = focusIndicatorColor,
               ),
             ),
           ),

--- a/lib/src/controls/yaru_window_control.dart
+++ b/lib/src/controls/yaru_window_control.dart
@@ -142,27 +142,25 @@ class _YaruWindowControlState extends State<YaruWindowControl>
   @override
   Widget build(BuildContext context) {
     return _buildEventDetectors(
-      RepaintBoundary(
-        child: AnimatedContainer(
-          duration: _kWindowControlBackgroundAnimationDuration,
-          decoration: BoxDecoration(
-            color: _getColor(context),
-            shape: BoxShape.circle,
-          ),
-          child: SizedBox.square(
-            dimension: kYaruWindowControlSize,
-            child: Center(
-              child: AnimatedBuilder(
-                animation: _position,
-                builder: (context, child) => CustomPaint(
-                  size: const Size.square(_kWindowControlIconSize),
-                  painter: _YaruWindowControlPainter(
-                    type: widget.type,
-                    oldType: oldType,
-                    iconColor: Theme.of(context).colorScheme.onSurface,
-                    position: _position.value,
-                    interactive: interactive,
-                  ),
+      AnimatedContainer(
+        duration: _kWindowControlBackgroundAnimationDuration,
+        decoration: BoxDecoration(
+          color: _getColor(context),
+          shape: BoxShape.circle,
+        ),
+        child: SizedBox.square(
+          dimension: kYaruWindowControlSize,
+          child: Center(
+            child: AnimatedBuilder(
+              animation: _position,
+              builder: (context, child) => CustomPaint(
+                size: const Size.square(_kWindowControlIconSize),
+                painter: _YaruWindowControlPainter(
+                  type: widget.type,
+                  oldType: oldType,
+                  iconColor: Theme.of(context).colorScheme.onSurface,
+                  position: _position.value,
+                  interactive: interactive,
                 ),
               ),
             ),


### PR DESCRIPTION
This PR removes all RepaintBoundary widgets, which can cause performance issue.
The only side effect is that window controls and togglable widgets will no more be aligned on physical display. It will result in blurred widgets in some situations, like inside alignment widgets.

I taken an attentive look, and all material widgets got the same behavior of blurred look.

Side by side, material and yaru checkboxes:

[Capture vidéo du 2023-01-14 17-39-38.webm](https://user-images.githubusercontent.com/36476595/212485708-e4c80e80-9710-4ce7-ac2d-bb6193528edf.webm)

Fixes #492

## Pull request checklist

- [x] This PR does not introduce visual changes