### PR TITLE
YaruTitleBar: fix single-click delay

### DIFF
--- a/lib/src/controls/yaru_title_bar.dart
+++ b/lib/src/controls/yaru_title_bar.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:yaru_colors/yaru_colors.dart';
 
 import '../constants.dart';
+import 'yaru_title_bar_gesture_detector.dart';
 import 'yaru_title_bar_theme.dart';
 import 'yaru_window.dart';
 import 'yaru_window_control.dart';
@@ -180,9 +181,8 @@ class YaruTitleBar extends StatelessWidget implements PreferredSizeWidget {
       );
     }
 
-    return GestureDetector(
-      behavior: HitTestBehavior.translucent,
-      onPanStart: isDraggable == true ? (_) => onDrag?.call(context) : null,
+    return YaruTitleBarGestureDetector(
+      onDrag: isDraggable == true ? (_) => onDrag?.call(context) : null,
       onDoubleTap: () => isMaximizable == true
           ? onMaximize?.call(context)
           : isRestorable == true

--- a/lib/src/controls/yaru_title_bar_gesture_detector.dart
+++ b/lib/src/controls/yaru_title_bar_gesture_detector.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/widgets.dart';
+
+class YaruTitleBarGestureDetector extends StatelessWidget {
+  const YaruTitleBarGestureDetector({
+    super.key,
+    this.onDrag,
+    this.onDoubleTap,
+    this.onSecondaryTap,
+    this.behavior = HitTestBehavior.translucent,
+    this.child,
+  });
+
+  final GestureDragStartCallback? onDrag;
+  final GestureDoubleTapCallback? onDoubleTap;
+  final GestureTapCallback? onSecondaryTap;
+  final HitTestBehavior? behavior;
+  final Widget? child;
+
+  @override
+  Widget build(BuildContext context) {
+    final settings = MediaQuery.maybeOf(context)?.gestureSettings;
+    return RawGestureDetector(
+      behavior: behavior,
+      gestures: {
+        PanGestureRecognizer:
+            GestureRecognizerFactoryWithHandlers<PanGestureRecognizer>(
+          PanGestureRecognizer.new,
+          (instance) => instance
+            ..onStart = onDrag
+            ..gestureSettings = settings,
+        ),
+        _PassiveTapGestureRecognizer:
+            GestureRecognizerFactoryWithHandlers<_PassiveTapGestureRecognizer>(
+          _PassiveTapGestureRecognizer.new,
+          (instance) => instance
+            ..onDoubleTap = onDoubleTap
+            ..onSecondaryTap = onSecondaryTap
+            ..gestureSettings = settings,
+        ),
+      },
+      child: child,
+    );
+  }
+}
+
+class _PassiveTapGestureRecognizer extends TapGestureRecognizer {
+  _PassiveTapGestureRecognizer() {
+    onTapUp = (_) {};
+    onTapCancel = () {};
+  }
+
+  GestureDoubleTapCallback? onDoubleTap;
+
+  PointerDownEvent? _firstTapDown;
+  PointerUpEvent? _firstTapUp;
+
+  @protected
+  @override
+  void handleTapUp({
+    required PointerDownEvent down,
+    required PointerUpEvent up,
+  }) {
+    super.handleTapUp(down: down, up: up);
+    if (onDoubleTap != null &&
+        _firstTapDown != null &&
+        _firstTapUp != null &&
+        down.buttons == kPrimaryButton) {
+      // the time from the start of the first tap to the start of the second tap
+      final interval = down.timeStamp - _firstTapDown!.timeStamp;
+      // the time from the end of the first tap to the start of the second tap
+      final timeBetween = down.timeStamp - _firstTapUp!.timeStamp;
+      // the distance between the first tap down and up
+      final slop = (_firstTapDown!.position - _firstTapUp!.position).distance;
+      // the distance between the first tap down and the second tap down
+      final secondSlop = (_firstTapDown!.position - down.position).distance;
+      if (interval < kDoubleTapTimeout &&
+          timeBetween >= kDoubleTapMinTime &&
+          slop <= kDoubleTapTouchSlop &&
+          secondSlop <= kDoubleTapSlop) {
+        invokeCallback<void>('onDoubleTap', onDoubleTap!);
+        _firstTapDown = null;
+        _firstTapUp = null;
+        return;
+      }
+    }
+    _firstTapDown = down;
+    _firstTapUp = up;
+  }
+
+  @protected
+  @override
+  void handleTapCancel({
+    required PointerDownEvent down,
+    PointerCancelEvent? cancel,
+    required String reason,
+  }) {
+    super.handleTapCancel(down: down, cancel: cancel, reason: reason);
+    _firstTapDown = null;
+    _firstTapUp = null;
+  }
+}

--- a/lib/src/controls/yaru_title_bar_gesture_detector.dart
+++ b/lib/src/controls/yaru_title_bar_gesture_detector.dart
@@ -66,11 +66,11 @@ class _PassiveTapGestureRecognizer extends TapGestureRecognizer {
         _firstTapDown != null &&
         _firstTapUp != null &&
         down.buttons == kPrimaryButton) {
-      // the time from the start of the first tap to the start of the second tap
+      // the time from the first tap down to the second tap down
       final interval = down.timeStamp - _firstTapDown!.timeStamp;
-      // the time from the end of the first tap to the start of the second tap
+      // the time from the first tap up to the second tap down
       final timeBetween = down.timeStamp - _firstTapUp!.timeStamp;
-      // the distance between the first tap down and up
+      // the distance between the first tap down and the first tap up
       final slop = (_firstTapDown!.position - _firstTapUp!.position).distance;
       // the distance between the first tap down and the second tap down
       final secondSlop = (_firstTapDown!.position - down.position).distance;


### PR DESCRIPTION
The problem was that `GestureDetector.onDoubleTap` creates an "eager" double-tap recognizer that forces a 300ms delay for any (single-)tap recognizer in the gesture arena.

This PR drops `GestureDetector` in favor of `RawGestureDetector` that allows using custom gesture recognizers, and implements a "passive" double-tap recognizer that is just an extended (single-)tap recognizer but detects double-taps from incoming (single-)taps. It keeps a history of the previous tap and compares the duration and distance with help of the constants defined in `flutter/gestures.dart`.

Fixes: #516