### PR TITLE
Add scaffold to yaru-master-detail page

### DIFF
--- a/lib/src/layouts/yaru_master_detail_page.dart
+++ b/lib/src/layouts/yaru_master_detail_page.dart
@@ -137,31 +137,33 @@ class _YaruMasterDetailPageState extends State<YaruMasterDetailPage> {
   Widget build(BuildContext context) {
     final breakpoint = YaruMasterDetailTheme.of(context).breakpoint ??
         YaruMasterDetailThemeData.fallback().breakpoint!;
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        if (constraints.maxWidth < breakpoint) {
-          return YaruPortraitLayout(
-            tileBuilder: widget.tileBuilder,
-            pageBuilder: widget.pageBuilder,
-            onSelected: widget.onSelected,
-            appBar: widget.appBar,
-            bottomBar: widget.bottomBar,
-            controller: _controller,
-          );
-        } else {
-          return YaruLandscapeLayout(
-            tileBuilder: widget.tileBuilder,
-            pageBuilder: widget.pageBuilder,
-            onSelected: widget.onSelected,
-            layoutDelegate: widget.layoutDelegate,
-            previousPaneWidth: _previousPaneWidth,
-            onLeftPaneWidthChange: (width) => _previousPaneWidth = width,
-            appBar: widget.appBar,
-            bottomBar: widget.bottomBar,
-            controller: _controller,
-          );
-        }
-      },
+    return Scaffold(
+      body: LayoutBuilder(
+        builder: (context, constraints) {
+          if (constraints.maxWidth < breakpoint) {
+            return YaruPortraitLayout(
+              tileBuilder: widget.tileBuilder,
+              pageBuilder: widget.pageBuilder,
+              onSelected: widget.onSelected,
+              appBar: widget.appBar,
+              bottomBar: widget.bottomBar,
+              controller: _controller,
+            );
+          } else {
+            return YaruLandscapeLayout(
+              tileBuilder: widget.tileBuilder,
+              pageBuilder: widget.pageBuilder,
+              onSelected: widget.onSelected,
+              layoutDelegate: widget.layoutDelegate,
+              previousPaneWidth: _previousPaneWidth,
+              onLeftPaneWidthChange: (width) => _previousPaneWidth = width,
+              appBar: widget.appBar,
+              bottomBar: widget.bottomBar,
+              controller: _controller,
+            );
+          }
+        },
+      ),
     );
   }
 }


### PR DESCRIPTION
Adds a scaffold to fix indefinite issues with flutter showing the root GTK window and therefore not applying the correct theme. This is a regression from main.

maybe fixes #522 

## Pull request checklist

- [x] This PR does not introduce visual changes, **or**
  - I ran `flutter test --update-goldens` and committed the changes if there were any, **or**
  - I added before/after/light/dark screenshots if the visual changes I made were not covered by golden tests.
    | |Before|After|
    |-|-|-|
    |Light|![Screenshot from 2023-01-15 01-55-09](https://user-images.githubusercontent.com/73116038/212513972-bb997948-e7e9-403b-ad80-c81456c87258.png)|![Screenshot from 2023-01-15 01-56-40](https://user-images.githubusercontent.com/73116038/212514146-35469ac3-85c4-49bf-9de0-283c6801dccb.png)  |
    |Dark|   ![Screenshot from 2023-01-15 01-58-47](https://user-images.githubusercontent.com/73116038/212514217-321cfa4c-806d-436b-9276-e2c857f1eafa.png)  |  ![Screenshot from 2023-01-15 01-58-06](https://user-images.githubusercontent.com/73116038/212514278-61b282a8-c30d-4625-b4e9-d7f2693c3458.png)  |