### PR TITLE
Allow color customization of single togglable

### DIFF
--- a/lib/src/controls/yaru_checkbox.dart
+++ b/lib/src/controls/yaru_checkbox.dart
@@ -44,6 +44,8 @@ class YaruCheckbox extends StatefulWidget implements YaruTogglable<bool?> {
     required this.value,
     this.tristate = false,
     required this.onChanged,
+    this.selectedColor,
+    this.checkmarkColor,
     this.focusNode,
     this.autofocus = false,
   }) : assert(tristate || value != null);
@@ -99,6 +101,18 @@ class YaruCheckbox extends StatefulWidget implements YaruTogglable<bool?> {
   /// ```
   @override
   final ValueChanged<bool?>? onChanged;
+
+  /// The color to use when this checkbox is checked.
+  ///
+  /// Defaults to [ColorScheme.primary].
+  @override
+  final Color? selectedColor;
+
+  /// The color to use for the checkmark when this checkbox is checked.
+  ///
+  /// Defaults to [ColorScheme.onPrimary].
+  @override
+  final Color? checkmarkColor;
 
   @override
   bool get interactive => onChanged != null;

--- a/lib/src/controls/yaru_radio.dart
+++ b/lib/src/controls/yaru_radio.dart
@@ -43,6 +43,8 @@ class YaruRadio<T> extends StatefulWidget implements YaruTogglable<T?> {
     required this.groupValue,
     this.toggleable = false,
     required this.onChanged,
+    this.selectedColor,
+    this.checkmarkColor,
     this.focusNode,
     this.autofocus = false,
   }) : assert(toggleable || value != null);
@@ -109,6 +111,18 @@ class YaruRadio<T> extends StatefulWidget implements YaruTogglable<T?> {
   /// ```
   @override
   final ValueChanged<T?>? onChanged;
+
+  /// The color to use when this radio is checked.
+  ///
+  /// Defaults to [ColorScheme.primary].
+  @override
+  final Color? selectedColor;
+
+  /// The color to use for the checkmark when this radio is checked.
+  ///
+  /// Defaults to [ColorScheme.onPrimary].
+  @override
+  final Color? checkmarkColor;
 
   @override
   bool get interactive => onChanged != null;

--- a/lib/src/controls/yaru_switch.dart
+++ b/lib/src/controls/yaru_switch.dart
@@ -35,6 +35,8 @@ class YaruSwitch extends StatefulWidget implements YaruTogglable<bool> {
     super.key,
     required this.value,
     required this.onChanged,
+    this.selectedColor,
+    this.checkmarkColor,
     this.focusNode,
     this.autofocus = false,
   });
@@ -75,6 +77,18 @@ class YaruSwitch extends StatefulWidget implements YaruTogglable<bool> {
   /// ```
   @override
   final ValueChanged<bool>? onChanged;
+
+  /// The color to use when this switch is on.
+  ///
+  /// Defaults to [ColorScheme.primary].
+  @override
+  final Color? selectedColor;
+
+  /// The color to use for the dot when this switch is on.
+  ///
+  /// Defaults to [ColorScheme.onPrimary].
+  @override
+  final Color? checkmarkColor;
 
   @override
   bool get interactive => onChanged != null;

--- a/lib/src/controls/yaru_togglable.dart
+++ b/lib/src/controls/yaru_togglable.dart
@@ -23,6 +23,8 @@ abstract class YaruTogglable<T> extends StatefulWidget {
     required this.value,
     this.tristate = false,
     required this.onChanged,
+    this.selectedColor,
+    this.checkmarkColor,
     this.focusNode,
     this.autofocus = false,
   });
@@ -44,6 +46,16 @@ abstract class YaruTogglable<T> extends StatefulWidget {
   /// [StatefulWidget] using the [State.setState] method, so that the parent
   /// gets rebuilt.
   final ValueChanged<T>? onChanged;
+
+  /// The color to use when this togglable is checked.
+  ///
+  /// Defaults to [ColorScheme.primary].
+  final Color? selectedColor;
+
+  /// The color to use for the checkmark when this togglable is checked.
+  ///
+  /// Defaults to [ColorScheme.onPrimary].
+  final Color? checkmarkColor;
 
   /// Determine if this [YaruTogglable] can handle events.
   bool get interactive;
@@ -236,8 +248,8 @@ abstract class YaruTogglableState<S extends YaruTogglable> extends State<S>
     // Normal colors
     final uncheckedColor = colorScheme.surface;
     final uncheckedBorderColor = colorScheme.onSurface.withOpacity(.3);
-    final checkedColor = colorScheme.primary;
-    final checkmarkColor = colorScheme.onPrimary;
+    final checkedColor = widget.selectedColor ?? colorScheme.primary;
+    final checkmarkColor = widget.checkmarkColor ?? colorScheme.onPrimary;
 
     // Disabled colors
     final uncheckedDisabledColor = colorScheme.onSurface.withOpacity(.1);


### PR DESCRIPTION
For example:

![Capture d’écran du 2023-01-15 13-09-58](https://user-images.githubusercontent.com/36476595/212540186-1ef78ddc-9134-4357-9559-c59a95dff5fa.png)

This is the part one of yaru togglable theming.
In a second time, maybe introduce some kind of app global theming? Wdyt @jpnurmi @Feichtmeier ?

Fixes #526

## Pull request checklist

- [x] This PR does not introduce visual changes