### PR TITLE
Landscape: remove separator fix for web, not needed anymore

### DIFF
--- a/lib/src/layouts/yaru_landscape_layout.dart
+++ b/lib/src/layouts/yaru_landscape_layout.dart
@@ -1,6 +1,5 @@
 import 'dart:math';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import '../controls/yaru_title_bar_theme.dart';
@@ -173,15 +172,6 @@ class _YaruLandscapeLayoutState extends State<YaruLandscapeLayout> {
   }
 
   Widget _buildVerticalSeparator() {
-    // Fix for the ultra white divider on flutter web
-    final darkAndWeb =
-        kIsWeb && Theme.of(context).brightness == Brightness.dark;
-    if (darkAndWeb) {
-      return const VerticalDivider(
-        thickness: 0,
-        width: 0.01,
-      );
-    }
     return const VerticalDivider(
       thickness: 1,
       width: 1,


### PR DESCRIPTION
since yaru master details now has a scaffold we dont need this anymore

![grafik](https://user-images.githubusercontent.com/15329494/212562663-6feb52a7-402b-496c-8452-9924a6d079b4.png)


## Pull request checklist

- [x] This PR does not introduce visual changes, **or**
  - I ran `flutter test --update-goldens` and committed the changes if there were any, **or**
  - I added before/after/light/dark screenshots if the visual changes I made were not covered by golden tests.
    | |Before|After|
    |-|-|-|
    |Light| | |
    |Dark| | |