### PR TITLE
YaruNavigationPage: add HeroController to support YaruDetailPage

### DIFF
--- a/lib/src/layouts/yaru_navigation_page.dart
+++ b/lib/src/layouts/yaru_navigation_page.dart
@@ -179,6 +179,7 @@ class _YaruNavigationPageState extends State<YaruNavigationPage> {
             ),
           ],
           onPopPage: (route, result) => route.didPop(result),
+          observers: [HeroController()],
         ),
       ),
     );


### PR DESCRIPTION
With quick and dirty changes to the example just to illustrate how it keeps the title bar in place during page transitions.

## Before

[Screencast from 2023-01-19 14-57-04.webm](https://user-images.githubusercontent.com/140617/213461424-8436d578-a369-49a0-99fc-d1292b8c30d5.webm)

## After

[Screencast from 2023-01-19 14-57-17.webm](https://user-images.githubusercontent.com/140617/213461466-ddc1a4b5-1023-4a77-a38e-4621a4fc7ba5.webm)
