### PR TITLE
Add missing RepaintBoundary on painter widgets

### DIFF
--- a/lib/src/controls/yaru_circular_progress_indicator.dart
+++ b/lib/src/controls/yaru_circular_progress_indicator.dart
@@ -110,7 +110,9 @@ class _YaruCircularProgressIndicatorState
           minWidth: _kMinCircularProgressIndicatorSize,
           minHeight: _kMinCircularProgressIndicatorSize,
         ),
-        child: child,
+        child: RepaintBoundary(
+          child: child,
+        ),
       ),
     );
   }

--- a/lib/src/controls/yaru_linear_progress_indicator.dart
+++ b/lib/src/controls/yaru_linear_progress_indicator.dart
@@ -109,7 +109,9 @@ class _YaruLinearProgressIndicatorState
           minWidth: double.infinity,
           minHeight: widget.minHeight,
         ),
-        child: child,
+        child: RepaintBoundary(
+          child: child,
+        ),
       ),
     );
   }


### PR DESCRIPTION
Add `RepaintBoundary` on the rest of our painter based widgets (progress indicators), to avoid blurred rendering cause to subpixel coordinates.

## Pull request checklist

- [x] This PR does not introduce visual changes