### PR TITLE
Example: fix the settings bottom bar look sensible with Flutter beta

### DIFF
--- a/example/lib/example.dart
+++ b/example/lib/example.dart
@@ -78,21 +78,16 @@ class _MasterDetailPage extends StatelessWidget {
       appBar: const YaruWindowTitleBar(
         title: Text('Yaru Widgets'),
       ),
-      bottomBar: BottomAppBar(
-        elevation: 0,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            const Divider(height: 1),
-            Padding(
-              padding: const EdgeInsets.symmetric(vertical: 8.0),
-              child: YaruMasterTile(
-                leading: const Icon(YaruIcons.gear),
-                title: const Text('Settings'),
-                onTap: () => showSettingsDialog(context),
-              ),
-            ),
-          ],
+      bottomBar: Material(
+        color: Theme.of(context).colorScheme.background,
+        shape: Border(top: BorderSide(color: Theme.of(context).dividerColor)),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 8.0),
+          child: YaruMasterTile(
+            leading: const Icon(YaruIcons.gear),
+            title: const Text('Settings'),
+            onTap: () => showSettingsDialog(context),
+          ),
         ),
       ),
     );


### PR DESCRIPTION
M3 bottom bar has gained default padding and a height of 80px on the beta channel. We can switch to a simpler structure to avoid having to customize it in the example. All we need is a tile with an opaque background and a little padding around. :)

| | Before | After |
|---|---|---|
| Stable | ![image](https://user-images.githubusercontent.com/140617/213649558-9574ec3b-119d-44c4-8f95-79229037f1bb.png) | ![image](https://user-images.githubusercontent.com/140617/213649287-28249220-21b7-4a83-bc8b-bbff7244c962.png) |
| Beta | ![image](https://user-images.githubusercontent.com/140617/213649643-9b778349-1e81-4586-abad-06cd95f55b10.png) | ![image](https://user-images.githubusercontent.com/140617/213649724-5e32bf39-55e3-4792-929f-f9f9d9dc1204.png) |

NOTE: The white divider is a separate issue discussed at:
- https://github.com/ubuntu/yaru.dart/issues/251