### PR TITLE
YaruDetailPage: allow specifying the hero tag

### DIFF
--- a/lib/src/layouts/yaru_detail_page.dart
+++ b/lib/src/layouts/yaru_detail_page.dart
@@ -1,5 +1,10 @@
 import 'package:flutter/material.dart';
 
+class _YaruDetailPageDefaultHeroTag {
+  const _YaruDetailPageDefaultHeroTag();
+  static Object id(Object? id) => '<_YaruDetailPageDefaultHeroTag $id>';
+}
+
 /// Provides the recommended layout for [YaruMasterDetailPage.pageBuilder].
 ///
 /// This widget is similar to [Scaffold] with the exception that it wraps the
@@ -19,6 +24,7 @@ class YaruDetailPage extends StatelessWidget {
     this.backgroundColor,
     this.extendBody = false,
     this.extendBodyBehindAppBar = false,
+    this.heroTag = const _YaruDetailPageDefaultHeroTag(),
   });
 
   /// See [Scaffold.extendBody].
@@ -57,13 +63,21 @@ class YaruDetailPage extends StatelessWidget {
   /// See [Scaffold.bottomSheet].
   final Widget? bottomSheet;
 
+  /// The tag to use for the [Hero] wrapping the [appBar].
+  ///
+  /// By default, a unique tag is used to ensure that the [appBar] stays in
+  /// place during page transitions. If set to `null`, no [Hero] will be used.
+  final Object? heroTag;
+
   PreferredSizeWidget? _buildAppBar(BuildContext context) {
-    if (appBar == null) return null;
+    if (appBar == null || heroTag == null) return appBar;
 
     return PreferredSize(
       preferredSize: appBar!.preferredSize,
       child: Hero(
-        tag: '<YaruDetailPage Hero tag - $appBar>',
+        tag: heroTag is _YaruDetailPageDefaultHeroTag
+            ? _YaruDetailPageDefaultHeroTag.id(appBar)
+            : heroTag!,
         child: appBar!,
       ),
     );

--- a/lib/src/layouts/yaru_detail_page.dart
+++ b/lib/src/layouts/yaru_detail_page.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 
-class _YaruDetailPageDefaultHeroTag {
-  const _YaruDetailPageDefaultHeroTag();
-  static Object id(Object? id) => '<_YaruDetailPageDefaultHeroTag $id>';
+class _YaruDetailPageHeroTag {
+  const _YaruDetailPageHeroTag();
+  static Object id(Object? id) => '<_YaruDetailPageHeroTag $id>';
 }
 
 /// Provides the recommended layout for [YaruMasterDetailPage.pageBuilder].
@@ -24,7 +24,7 @@ class YaruDetailPage extends StatelessWidget {
     this.backgroundColor,
     this.extendBody = false,
     this.extendBodyBehindAppBar = false,
-    this.heroTag = const _YaruDetailPageDefaultHeroTag(),
+    this.heroTag = const _YaruDetailPageHeroTag(),
   });
 
   /// See [Scaffold.extendBody].
@@ -75,8 +75,8 @@ class YaruDetailPage extends StatelessWidget {
     return PreferredSize(
       preferredSize: appBar!.preferredSize,
       child: Hero(
-        tag: heroTag is _YaruDetailPageDefaultHeroTag
-            ? _YaruDetailPageDefaultHeroTag.id(appBar)
+        tag: heroTag is _YaruDetailPageHeroTag
+            ? _YaruDetailPageHeroTag.id(appBar)
             : heroTag!,
         child: appBar!,
       ),

--- a/lib/src/layouts/yaru_detail_page.dart
+++ b/lib/src/layouts/yaru_detail_page.dart
@@ -1,9 +1,6 @@
 import 'package:flutter/material.dart';
 
-class _YaruDetailPageHeroTag {
-  const _YaruDetailPageHeroTag();
-  static Object id(Object? id) => '<_YaruDetailPageHeroTag $id>';
-}
+const _kYaruDetailPageHeroTag = '<YaruDetailPageHeroTag>';
 
 /// Provides the recommended layout for [YaruMasterDetailPage.pageBuilder].
 ///
@@ -24,7 +21,7 @@ class YaruDetailPage extends StatelessWidget {
     this.backgroundColor,
     this.extendBody = false,
     this.extendBodyBehindAppBar = false,
-    this.heroTag = const _YaruDetailPageHeroTag(),
+    this.heroTag = _kYaruDetailPageHeroTag,
   });
 
   /// See [Scaffold.extendBody].
@@ -70,14 +67,16 @@ class YaruDetailPage extends StatelessWidget {
   final Object? heroTag;
 
   PreferredSizeWidget? _buildAppBar(BuildContext context) {
-    if (appBar == null || heroTag == null) return appBar;
+    if (appBar == null ||
+        heroTag == null ||
+        context.findAncestorWidgetOfExactType<Hero>() != null) {
+      return appBar;
+    }
 
     return PreferredSize(
       preferredSize: appBar!.preferredSize,
       child: Hero(
-        tag: heroTag is _YaruDetailPageHeroTag
-            ? _YaruDetailPageHeroTag.id(appBar)
-            : heroTag!,
+        tag: heroTag!,
         child: appBar!,
       ),
     );

--- a/lib/src/layouts/yaru_detail_page.dart
+++ b/lib/src/layouts/yaru_detail_page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-const _kYaruDetailPageHeroTag = '<YaruDetailPageHeroTag>';
+const _kYaruDetailPageHeroTag = '<YaruDetailPage hero tag>';
 
 /// Provides the recommended layout for [YaruMasterDetailPage.pageBuilder].
 ///


### PR DESCRIPTION
No visual changes. A partial fix to #549. Something similar for YaruTitleBar comes separately.