### PR TITLE
YaruWindowTitleBar: allow notifying window state changes

### DIFF
--- a/lib/src/controls/yaru_title_bar.dart
+++ b/lib/src/controls/yaru_title_bar.dart
@@ -388,6 +388,17 @@ class YaruWindowTitleBar extends StatelessWidget
 
   static Future<void> ensureInitialized() => YaruWindow.ensureInitialized();
 
+  /// Updates the title bar to reflect the native window state and attributes.
+  ///
+  /// Even though [YaruWindowTitleBar] listens to native window state changes
+  /// (minimized, maximized, fullscreen), it is not possible to detect changes
+  /// to native window attributes (closable, minimizable, maximizable) after the
+  /// window has been created. This method can be called when changing window
+  /// attributes at runtime.
+  static Future<void> updateState(BuildContext context) {
+    return YaruWindow.updateState(context);
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = YaruTitleBarTheme.of(context);

--- a/lib/src/controls/yaru_window.dart
+++ b/lib/src/controls/yaru_window.dart
@@ -57,6 +57,10 @@ class YaruWindow {
       await windowManager.setTitleBarStyle(TitleBarStyle.hidden);
     }
   }
+
+  static Future<void> updateState(BuildContext context) {
+    return YaruWindow.of(context).updateState();
+  }
 }
 
 class YaruWindowInstance {
@@ -74,6 +78,7 @@ class YaruWindowInstance {
   Future<void> minimize() => wm.minimize().catchError((_) {});
   Future<void> restore() => wm.unmaximize().catchError((_) {});
   Future<void> showMenu() => wm.popUpWindowMenu().catchError((_) {});
+  Future<void> updateState() => _listener._updateState();
 
   YaruWindowState? get state => _listener.state;
   Stream<YaruWindowState> states() => _listener.states();
@@ -184,11 +189,7 @@ class YaruWindowListener implements WindowListener {
   @override
   void onWindowMoved() {}
   @override
-  void onWindowEvent(String eventName) {
-    if (eventName == 'state') {
-      _updateState();
-    }
-  }
+  void onWindowEvent(String eventName) {}
 }
 
 @immutable

--- a/lib/src/controls/yaru_window.dart
+++ b/lib/src/controls/yaru_window.dart
@@ -184,7 +184,11 @@ class YaruWindowListener implements WindowListener {
   @override
   void onWindowMoved() {}
   @override
-  void onWindowEvent(String eventName) {}
+  void onWindowEvent(String eventName) {
+    if (eventName == 'state') {
+      _updateState();
+    }
+  }
 }
 
 @immutable


### PR DESCRIPTION
Currently, `WindowManager` offers no way to listen to changes in whether a window is minimizable/maximizable/closable (leanflutter/window_manager#287).

This PR adds a hidden way for applications to notify that the title bar should update itself as required for canonical/ubuntu-desktop-installer#1329.