### PR TITLE
Expose YaruWindow API

### DIFF
--- a/lib/src/controls/yaru_title_bar.dart
+++ b/lib/src/controls/yaru_title_bar.dart
@@ -388,17 +388,6 @@ class YaruWindowTitleBar extends StatelessWidget
 
   static Future<void> ensureInitialized() => YaruWindow.ensureInitialized();
 
-  /// Updates the title bar to reflect the native window state and attributes.
-  ///
-  /// Even though [YaruWindowTitleBar] listens to native window state changes
-  /// (minimized, maximized, fullscreen), it is not possible to detect changes
-  /// to native window attributes (closable, minimizable, maximizable) after the
-  /// window has been created. This method can be called when changing window
-  /// attributes at runtime.
-  static Future<void> updateState(BuildContext context) {
-    return YaruWindow.updateState(context);
-  }
-
   @override
   Widget build(BuildContext context) {
     final theme = YaruTitleBarTheme.of(context);

--- a/lib/src/controls/yaru_window.dart
+++ b/lib/src/controls/yaru_window.dart
@@ -38,6 +38,22 @@ class YaruWindow {
     return YaruWindow.of(context).showMenu();
   }
 
+  static Future<void> setTitle(BuildContext context, String title) {
+    return YaruWindow.of(context).setTitle(title);
+  }
+
+  static Future<void> setMinimizable(BuildContext context, bool minimizable) {
+    return YaruWindow.of(context).setMinimizable(minimizable);
+  }
+
+  static Future<void> setMaximizable(BuildContext context, bool maximizable) {
+    return YaruWindow.of(context).setMaximizable(maximizable);
+  }
+
+  static Future<void> setClosable(BuildContext context, bool closable) {
+    return YaruWindow.of(context).setClosable(closable);
+  }
+
   static YaruWindowState? state(BuildContext context) {
     return YaruWindow.of(context).state;
   }
@@ -57,10 +73,6 @@ class YaruWindow {
       await windowManager.setTitleBarStyle(TitleBarStyle.hidden);
     }
   }
-
-  static Future<void> updateState(BuildContext context) {
-    return YaruWindow.of(context).updateState();
-  }
 }
 
 class YaruWindowInstance {
@@ -78,7 +90,23 @@ class YaruWindowInstance {
   Future<void> minimize() => wm.minimize().catchError((_) {});
   Future<void> restore() => wm.unmaximize().catchError((_) {});
   Future<void> showMenu() => wm.popUpWindowMenu().catchError((_) {});
-  Future<void> updateState() => _listener._updateState();
+
+  Future<void> setTitle(String title) => wm
+      .setTitle(title)
+      .catchError((_) {})
+      .then((_) => _listener._updateState());
+  Future<void> setMinimizable(bool minimizable) => wm
+      .setMinimizable(minimizable)
+      .catchError((_) {})
+      .then((_) => _listener._updateState());
+  Future<void> setMaximizable(bool maximizable) => wm
+      .setMaximizable(maximizable)
+      .catchError((_) {})
+      .then((_) => _listener._updateState());
+  Future<void> setClosable(bool closable) => wm
+      .setClosable(closable)
+      .catchError((_) {})
+      .then((_) => _listener._updateState());
 
   YaruWindowState? get state => _listener.state;
   Stream<YaruWindowState> states() => _listener.states();

--- a/lib/yaru_widgets.dart
+++ b/lib/yaru_widgets.dart
@@ -25,6 +25,7 @@ export 'src/controls/yaru_title_bar.dart';
 export 'src/controls/yaru_title_bar_theme.dart';
 export 'src/controls/yaru_toggle_button.dart';
 export 'src/controls/yaru_toggle_button_theme.dart';
+export 'src/controls/yaru_window.dart' show YaruWindow;
 export 'src/controls/yaru_window_control.dart';
 // Extensions
 export 'src/extensions/border_radius_extension.dart';


### PR DESCRIPTION
This allows apps to set the window title, and the relevant window attributes (minimizable, maximizable, closable) in a way that doesn't need the recently added [updateState()](https://github.com/ubuntu/yaru_widgets.dart/pull/561) workaround.

Before:
```dart
windowManager.setClosable(false);
YaruWindow.of(context).updateState(); // or YaruWindow.updateState(context);
```

After:
```dart
YaruWindow.of(context).setClosable(false); // or YaruWindow.setClosable(context, false);
```
