### PR TITLE
Prevent YaruTitleBar from reseting input focus

### DIFF
--- a/lib/src/controls/yaru_title_bar.dart
+++ b/lib/src/controls/yaru_title_bar.dart
@@ -193,78 +193,80 @@ class YaruTitleBar extends StatelessWidget implements PreferredSizeWidget {
       );
     }
 
-    return YaruTitleBarGestureDetector(
-      onDrag: isDraggable == true ? (_) => onDrag?.call(context) : null,
-      onDoubleTap: () => isMaximizable == true
-          ? onMaximize?.call(context)
-          : isRestorable == true
-              ? onRestore?.call(context)
-              : null,
-      onSecondaryTap: onShowMenu != null ? () => onShowMenu!(context) : null,
-      child: AppBar(
-        elevation: titleBarTheme.elevation,
-        automaticallyImplyLeading: false,
-        leading: backdropEffect(leading),
-        title: backdropEffect(title),
-        centerTitle: centerTitle ?? titleBarTheme.centerTitle,
-        titleSpacing: titleSpacing ?? titleBarTheme.titleSpacing,
-        toolbarHeight: kYaruTitleBarHeight,
-        foregroundColor: foregroundColor,
-        backgroundColor: backgroundColor,
-        titleTextStyle: titleTextStyle,
-        shape: shape,
-        actions: [
-          maybeHero(
-            child: backdropEffect(
-              Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  ...?actions,
-                  if (style == YaruTitleBarStyle.normal &&
-                      (isMinimizable == true ||
-                          isRestorable == true ||
-                          isMaximizable == true ||
-                          isClosable == true))
-                    Padding(
-                      padding: buttonPadding,
-                      child: Row(
-                        children: [
-                          if (isMinimizable == true)
-                            YaruWindowControl(
-                              type: YaruWindowControlType.minimize,
-                              onTap: onMinimize != null
-                                  ? () => onMinimize!(context)
-                                  : null,
-                            ),
-                          if (isRestorable == true)
-                            YaruWindowControl(
-                              type: YaruWindowControlType.restore,
-                              onTap: onRestore != null
-                                  ? () => onRestore!(context)
-                                  : null,
-                            ),
-                          if (isMaximizable == true)
-                            YaruWindowControl(
-                              type: YaruWindowControlType.maximize,
-                              onTap: onMaximize != null
-                                  ? () => onMaximize!(context)
-                                  : null,
-                            ),
-                          if (isClosable == true)
-                            YaruWindowControl(
-                              type: YaruWindowControlType.close,
-                              onTap: onClose != null
-                                  ? () => onClose!(context)
-                                  : null,
-                            ),
-                        ].withSpacing(buttonSpacing),
+    return TextFieldTapRegion(
+      child: YaruTitleBarGestureDetector(
+        onDrag: isDraggable == true ? (_) => onDrag?.call(context) : null,
+        onDoubleTap: () => isMaximizable == true
+            ? onMaximize?.call(context)
+            : isRestorable == true
+                ? onRestore?.call(context)
+                : null,
+        onSecondaryTap: onShowMenu != null ? () => onShowMenu!(context) : null,
+        child: AppBar(
+          elevation: titleBarTheme.elevation,
+          automaticallyImplyLeading: false,
+          leading: backdropEffect(leading),
+          title: backdropEffect(title),
+          centerTitle: centerTitle ?? titleBarTheme.centerTitle,
+          titleSpacing: titleSpacing ?? titleBarTheme.titleSpacing,
+          toolbarHeight: kYaruTitleBarHeight,
+          foregroundColor: foregroundColor,
+          backgroundColor: backgroundColor,
+          titleTextStyle: titleTextStyle,
+          shape: shape,
+          actions: [
+            maybeHero(
+              child: backdropEffect(
+                Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    ...?actions,
+                    if (style == YaruTitleBarStyle.normal &&
+                        (isMinimizable == true ||
+                            isRestorable == true ||
+                            isMaximizable == true ||
+                            isClosable == true))
+                      Padding(
+                        padding: buttonPadding,
+                        child: Row(
+                          children: [
+                            if (isMinimizable == true)
+                              YaruWindowControl(
+                                type: YaruWindowControlType.minimize,
+                                onTap: onMinimize != null
+                                    ? () => onMinimize!(context)
+                                    : null,
+                              ),
+                            if (isRestorable == true)
+                              YaruWindowControl(
+                                type: YaruWindowControlType.restore,
+                                onTap: onRestore != null
+                                    ? () => onRestore!(context)
+                                    : null,
+                              ),
+                            if (isMaximizable == true)
+                              YaruWindowControl(
+                                type: YaruWindowControlType.maximize,
+                                onTap: onMaximize != null
+                                    ? () => onMaximize!(context)
+                                    : null,
+                              ),
+                            if (isClosable == true)
+                              YaruWindowControl(
+                                type: YaruWindowControlType.close,
+                                onTap: onClose != null
+                                    ? () => onClose!(context)
+                                    : null,
+                              ),
+                          ].withSpacing(buttonSpacing),
+                        ),
                       ),
-                    ),
-                ],
-              ),
-            )!,
-          ),
-        ],
+                  ],
+                ),
+              )!,
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ version: 2.0.0-beta-5
 
 environment:
   sdk: ">=2.17.0 <3.0.0"
-  flutter: ">=3.3.0"
+  flutter: ">=3.7.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
TextFieldTapRegion was introduced in Flutter 3.7.0 to solve the problem that clicking anywhere outside a TextField would reset input focus.

### Before
[Screencast from 2023-01-26 22-09-34.webm](https://user-images.githubusercontent.com/140617/214951225-0a6e6b31-6335-4426-a670-86e7a0dacdc0.webm)

### After
[Screencast from 2023-01-26 22-07-55.webm](https://user-images.githubusercontent.com/140617/214951249-61fe399a-7139-477e-b4d8-69c0fc058093.webm)

Fixes: #550