### PR TITLE
Release 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+# 2.0.0
+
+* Fix YaruTile wrong text color by @Jupi007 in https://github.com/ubuntu/yaru_widgets.dart/pull/560
+* YaruWindowTitleBar: allow notifying window state changes by @jpnurmi in https://github.com/ubuntu/yaru_widgets.dart/pull/561
+* Expose YaruWindow API by @jpnurmi in https://github.com/ubuntu/yaru_widgets.dart/pull/562
+* Update goldens with Flutter 3.7.0 & latest yaru by @jpnurmi in https://github.com/ubuntu/yaru_widgets.dart/pull/564
+* CI: no need to run tests when publishing to GH pages by @jpnurmi in https://github.com/ubuntu/yaru_widgets.dart/pull/563
+* Fix YaruNavigationPageThemeData class name by @jpnurmi in https://github.com/ubuntu/yaru_widgets.dart/pull/565
+* Prevent YaruTitleBar from reseting input focus by @jpnurmi in https://github.com/ubuntu/yaru_widgets.dart/pull/566
+* YaruBorderRadiusExtension by @jpnurmi in https://github.com/ubuntu/yaru_widgets.dart/pull/567
+
 # 2.0.0-beta-5
 
 * Landscape: remove separator fix for web, not needed anymore by @Feichtmeier in https://github.com/ubuntu/yaru_widgets.dart/pull/529

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: yaru_widgets
 description: Common flutter widgets useful for building desktop and web applications.
 homepage: https://github.com/ubuntu/yaru_widgets.dart
 
-version: 2.0.0-beta-5
+version: 2.0.0
 
 environment:
   sdk: ">=2.17.0 <3.0.0"


### PR DESCRIPTION
* Fix YaruTile wrong text color by @Jupi007 in https://github.com/ubuntu/yaru_widgets.dart/pull/560
* YaruWindowTitleBar: allow notifying window state changes by @jpnurmi in https://github.com/ubuntu/yaru_widgets.dart/pull/561
* Expose YaruWindow API by @jpnurmi in https://github.com/ubuntu/yaru_widgets.dart/pull/562
* Update goldens with Flutter 3.7.0 & latest yaru by @jpnurmi in https://github.com/ubuntu/yaru_widgets.dart/pull/564
* CI: no need to run tests when publishing to GH pages by @jpnurmi in https://github.com/ubuntu/yaru_widgets.dart/pull/563
* Fix YaruNavigationPageThemeData class name by @jpnurmi in https://github.com/ubuntu/yaru_widgets.dart/pull/565
* Prevent YaruTitleBar from reseting input focus by @jpnurmi in https://github.com/ubuntu/yaru_widgets.dart/pull/566
* YaruBorderRadiusExtension by @jpnurmi in https://github.com/ubuntu/yaru_widgets.dart/pull/567