### PR TITLE
Allow YaruNavigationRailItem width control

### DIFF
--- a/lib/src/layouts/yaru_navigation_rail_item.dart
+++ b/lib/src/layouts/yaru_navigation_rail_item.dart
@@ -2,13 +2,16 @@ import 'package:flutter/material.dart';
 
 /// Defines the look of a [YaruNavigationRailItem]
 enum YaruNavigationRailStyle {
-  /// Will only show icons
+  /// Will only show icons.
+  /// Default width: 60
   compact,
 
-  /// Will show both icons and labels vertically
+  /// Will show both icons and labels vertically.
+  /// Default width: 100
   labelled,
 
-  /// Will show both icons and labels horizontally
+  /// Will show both icons and labels horizontally.
+  /// Default width: 250
   labelledExtended,
 }
 
@@ -25,6 +28,7 @@ class YaruNavigationRailItem extends StatefulWidget {
     this.tooltip,
     this.onTap,
     required this.style,
+    this.width,
   });
 
   /// Whether the related page item is selected in the rail.
@@ -46,6 +50,10 @@ class YaruNavigationRailItem extends StatefulWidget {
 
   /// Style of this tile, see [YaruNavigationRailStyle].
   final YaruNavigationRailStyle style;
+
+  /// Defines the width of this tile.
+  /// If null, it will use default values, see [YaruNavigationRailStyle].
+  final double? width;
 
   @override
   State<YaruNavigationRailItem> createState() => _YaruNavigationRailItemState();
@@ -113,6 +121,10 @@ class _YaruNavigationRailItemState extends State<YaruNavigationRailItem> {
   }
 
   double get _width {
+    if (widget.width != null) {
+      return widget.width!;
+    }
+
     switch (widget.style) {
       case YaruNavigationRailStyle.labelledExtended:
         return 250;


### PR DESCRIPTION
The current way of control a navigation page pane width weird because it is done by tiles themself.
For now I added a way to control this width, I'll think about something to control this size from the navigation page itself, without introduce breaking change later (in any case these changes are needed).

![image](https://user-images.githubusercontent.com/36476595/215269666-29b9b11d-6c32-45be-8c57-485c2e07dea5.png)

Related to #570

## Pull request checklist

- [x] This PR does not introduce visual changes