### PR TITLE
Allow switch dot to be mouse dragged

### DIFF
--- a/lib/src/controls/yaru_switch.dart
+++ b/lib/src/controls/yaru_switch.dart
@@ -149,7 +149,7 @@ class _YaruSwitchState extends YaruTogglableState<YaruSwitch> {
     }
 
     return GestureDetector(
-      onPanStart: (details) => setState(() {
+      onPanStart: (details) {
         final dotSize = _kSwitchSize.height * _kSwitchDotSizeFactor;
         final dotGap = (_kSwitchSize.height - dotSize) / 2;
 
@@ -160,43 +160,49 @@ class _YaruSwitchState extends YaruTogglableState<YaruSwitch> {
 
         if (details.localPosition.dx >= minDragX &&
             details.localPosition.dx <= maxDragX) {
-          isDragging = true;
-          handleActiveChange(true);
+          setState(() {
+            isDragging = true;
+            handleActiveChange(true);
+          });
         }
-      }),
-      onPanUpdate: (details) => setState(() {
+      },
+      onPanUpdate: (details) {
         if (!isDragging) {
           return;
         }
 
-        final dotSize = _kSwitchSize.height * _kSwitchDotSizeFactor;
-        final dotGap = (_kSwitchSize.height - dotSize) / 2;
-        final dragGap = dotGap + dotSize / 2;
-        final innerWidth = _kSwitchSize.width - dragGap * 2;
+        setState(() {
+          final dotSize = _kSwitchSize.height * _kSwitchDotSizeFactor;
+          final dotGap = (_kSwitchSize.height - dotSize) / 2;
+          final dragGap = dotGap + dotSize / 2;
+          final innerWidth = _kSwitchSize.width - dragGap * 2;
 
-        positionController.value =
-            (details.localPosition.dx - dragGap) / innerWidth;
-      }),
-      onPanEnd: (details) => setState(() {
+          positionController.value =
+              (details.localPosition.dx - dragGap) / innerWidth;
+        });
+      },
+      onPanEnd: (details) {
         if (!isDragging) {
           return;
         }
 
-        isDragging = false;
-        handleActiveChange(false);
+        setState(() {
+          isDragging = false;
+          handleActiveChange(false);
 
-        if (positionController.value < .5) {
-          if (widget.value != false) {
-            widget.onChanged!(false);
+          if (positionController.value < .5) {
+            if (widget.value != false) {
+              widget.onChanged!(false);
+            }
+            positionController.animateTo(0);
+          } else {
+            if (widget.value != true) {
+              widget.onChanged!(true);
+            }
+            positionController.animateTo(1);
           }
-          positionController.animateTo(0);
-        } else {
-          if (widget.value != true) {
-            widget.onChanged!(true);
-          }
-          positionController.animateTo(1);
-        }
-      }),
+        });
+      },
       child: child,
     );
   }

--- a/lib/src/controls/yaru_switch.dart
+++ b/lib/src/controls/yaru_switch.dart
@@ -114,6 +114,8 @@ class _YaruSwitchState extends YaruTogglableState<YaruSwitch> {
   @override
   Size get togglableSize => _kSwitchSize;
 
+  bool isDragging = false;
+
   @override
   void handleTap([Intent? _]) {
     if (!widget.interactive) {
@@ -131,11 +133,71 @@ class _YaruSwitchState extends YaruTogglableState<YaruSwitch> {
     const uncheckedDotColor = Colors.white;
     final disabledDotColor = colorScheme.onSurface.withOpacity(.4);
 
-    return buildToggleable(
-      _YaruSwitchPainter()
-        ..uncheckedSwitchColor = uncheckedSwitchColor
-        ..uncheckedDotColor = uncheckedDotColor
-        ..disabledDotColor = disabledDotColor,
+    return _maybeBuildGestureDetector(
+      buildToggleable(
+        _YaruSwitchPainter()
+          ..uncheckedSwitchColor = uncheckedSwitchColor
+          ..uncheckedDotColor = uncheckedDotColor
+          ..disabledDotColor = disabledDotColor,
+      ),
+    );
+  }
+
+  Widget _maybeBuildGestureDetector(Widget child) {
+    if (!widget.interactive) {
+      return child;
+    }
+
+    return GestureDetector(
+      onPanStart: (details) => setState(() {
+        final dotSize = _kSwitchSize.height * _kSwitchDotSizeFactor;
+        final dotGap = (_kSwitchSize.height - dotSize) / 2;
+
+        final minDragX =
+            widget.value ? _kSwitchSize.width - (dotGap + dotSize) : dotGap;
+        final maxDragX =
+            widget.value ? _kSwitchSize.width - dotGap : dotGap + dotSize;
+
+        if (details.localPosition.dx >= minDragX &&
+            details.localPosition.dx <= maxDragX) {
+          isDragging = true;
+          handleActiveChange(true);
+        }
+      }),
+      onPanUpdate: (details) => setState(() {
+        if (!isDragging) {
+          return;
+        }
+
+        final dotSize = _kSwitchSize.height * _kSwitchDotSizeFactor;
+        final dotGap = (_kSwitchSize.height - dotSize) / 2;
+        final dragGap = dotGap + dotSize / 2;
+        final innerWidth = _kSwitchSize.width - dragGap * 2;
+
+        positionController.value =
+            (details.localPosition.dx - dragGap) / innerWidth;
+      }),
+      onPanEnd: (details) => setState(() {
+        if (!isDragging) {
+          return;
+        }
+
+        isDragging = false;
+        handleActiveChange(false);
+
+        if (positionController.value < .5) {
+          if (widget.value != false) {
+            widget.onChanged!(false);
+          }
+          positionController.animateTo(0);
+        } else {
+          if (widget.value != true) {
+            widget.onChanged!(true);
+          }
+          positionController.animateTo(1);
+        }
+      }),
+      child: child,
     );
   }
 }

--- a/lib/src/controls/yaru_switch.dart
+++ b/lib/src/controls/yaru_switch.dart
@@ -171,15 +171,13 @@ class _YaruSwitchState extends YaruTogglableState<YaruSwitch> {
           return;
         }
 
-        setState(() {
-          final dotSize = _kSwitchSize.height * _kSwitchDotSizeFactor;
-          final dotGap = (_kSwitchSize.height - dotSize) / 2;
-          final dragGap = dotGap + dotSize / 2;
-          final innerWidth = _kSwitchSize.width - dragGap * 2;
+        final dotSize = _kSwitchSize.height * _kSwitchDotSizeFactor;
+        final dotGap = (_kSwitchSize.height - dotSize) / 2;
+        final dragGap = dotGap + dotSize / 2;
+        final innerWidth = _kSwitchSize.width - dragGap * 2;
 
-          positionController.value =
-              (details.localPosition.dx - dragGap) / innerWidth;
-        });
+        positionController.value =
+            (details.localPosition.dx - dragGap) / innerWidth;
       },
       onPanEnd: (details) {
         if (!isDragging) {

--- a/lib/src/controls/yaru_togglable.dart
+++ b/lib/src/controls/yaru_togglable.dart
@@ -69,19 +69,19 @@ abstract class YaruTogglable<T> extends StatefulWidget {
 
 abstract class YaruTogglableState<S extends YaruTogglable> extends State<S>
     with TickerProviderStateMixin {
-  bool _hover = false;
-  bool _focus = false;
-  bool _active = false;
-  bool? _oldChecked;
+  bool hover = false;
+  bool focus = false;
+  bool active = false;
+  bool? oldChecked;
 
-  late CurvedAnimation _position;
-  late AnimationController _positionController;
+  late CurvedAnimation position;
+  late AnimationController positionController;
 
-  late CurvedAnimation _sizePosition;
-  late AnimationController _sizeController;
+  late CurvedAnimation sizePosition;
+  late AnimationController sizeController;
 
-  late CurvedAnimation _indicatorPosition;
-  late AnimationController _indicatorController;
+  late CurvedAnimation indicatorPosition;
+  late AnimationController indicatorController;
 
   late final Map<Type, Action<Intent>> _actionMap = <Type, Action<Intent>>{
     ActivateIntent: CallbackAction<ActivateIntent>(onInvoke: handleTap),
@@ -94,35 +94,35 @@ abstract class YaruTogglableState<S extends YaruTogglable> extends State<S>
   void initState() {
     super.initState();
 
-    _oldChecked = widget.checked;
+    oldChecked = widget.checked;
 
-    _positionController = AnimationController(
+    positionController = AnimationController(
       duration: _kTogglableAnimationDuration,
       value: widget.checked == false ? 0.0 : 1.0,
       vsync: this,
     );
-    _position = CurvedAnimation(
-      parent: _positionController,
+    position = CurvedAnimation(
+      parent: positionController,
       curve: Curves.easeInQuad,
       reverseCurve: Curves.easeOutQuad,
     );
 
-    _sizeController = AnimationController(
+    sizeController = AnimationController(
       duration: _kTogglableSizeAnimationDuration,
       vsync: this,
     );
-    _sizePosition = CurvedAnimation(
-      parent: _sizeController,
+    sizePosition = CurvedAnimation(
+      parent: sizeController,
       curve: Curves.easeIn,
       reverseCurve: Curves.easeOut,
     );
 
-    _indicatorController = AnimationController(
+    indicatorController = AnimationController(
       duration: _kIndicatorAnimationDuration,
       vsync: this,
     );
-    _indicatorPosition = CurvedAnimation(
-      parent: _indicatorController,
+    indicatorPosition = CurvedAnimation(
+      parent: indicatorController,
       curve: Curves.fastOutSlowIn,
     );
   }
@@ -132,79 +132,79 @@ abstract class YaruTogglableState<S extends YaruTogglable> extends State<S>
     super.didUpdateWidget(oldWidget);
 
     if (oldWidget.checked != widget.checked) {
-      _oldChecked = oldWidget.checked;
+      oldChecked = oldWidget.checked;
 
       if (widget.tristate) {
         if (widget.checked == null) {
-          _positionController.value = 0.0;
+          positionController.value = 0.0;
         }
         if (widget.checked ?? true) {
-          _positionController.forward();
+          positionController.forward();
         } else {
-          _positionController.reverse();
+          positionController.reverse();
         }
       } else {
         if (widget.checked ?? false) {
-          _positionController.forward();
+          positionController.forward();
         } else {
-          _positionController.reverse();
+          positionController.reverse();
         }
       }
 
-      _sizeController.forward().then((_) {
-        _sizeController.reverse();
+      sizeController.forward().then((_) {
+        sizeController.reverse();
       });
     }
   }
 
   @override
   void dispose() {
-    _positionController.dispose();
-    _indicatorController.dispose();
-    _sizeController.dispose();
+    positionController.dispose();
+    indicatorController.dispose();
+    sizeController.dispose();
 
     super.dispose();
   }
 
-  void _handleFocusChange(bool value) {
-    if (_focus == value) {
+  void handleFocusChange(bool value) {
+    if (focus == value) {
       return;
     }
 
-    setState(() => _focus = value);
+    setState(() => focus = value);
 
-    if (_focus) {
-      _indicatorController.forward();
+    if (focus) {
+      indicatorController.forward();
     } else {
-      _indicatorController.reverse();
+      indicatorController.reverse();
     }
   }
 
-  void _handleHoverChange(bool value) {
-    if (_hover == value) {
+  void handleHoverChange(bool value) {
+    if (hover == value) {
       return;
     }
 
-    setState(() => _hover = value);
+    setState(() => hover = value);
 
-    if (_hover) {
-      _indicatorController.forward();
+    if (hover) {
+      indicatorController.forward();
     } else {
-      _indicatorController.reverse();
+      indicatorController.reverse();
     }
   }
 
-  void _handleActiveChange(bool value) {
-    if (_active == value) {
+  void handleActiveChange(bool value) {
+    if (active == value) {
       return;
     }
 
-    setState(() => _active = value);
+    setState(() => active = value);
 
-    if (_active) {
-      _sizeController.forward();
+    if (active) {
+      sizeController.forward();
     } else {
-      _sizeController.reverse();
+      sizeController.reverse();
     }
   }
 
@@ -224,17 +224,17 @@ abstract class YaruTogglableState<S extends YaruTogglable> extends State<S>
       enabled: widget.interactive,
       focusNode: widget.focusNode,
       autofocus: widget.autofocus,
-      onShowFocusHighlight: _handleFocusChange,
-      onShowHoverHighlight: _handleHoverChange,
+      onShowFocusHighlight: handleFocusChange,
+      onShowHoverHighlight: handleHoverChange,
       mouseCursor: widget.interactive
           ? SystemMouseCursors.click
           : SystemMouseCursors.basic,
       child: GestureDetector(
         excludeFromSemantics: !widget.interactive,
-        onTapDown: (_) => _handleActiveChange(widget.interactive),
+        onTapDown: (_) => handleActiveChange(widget.interactive),
         onTap: handleTap,
-        onTapUp: (_) => _handleActiveChange(false),
-        onTapCancel: () => _handleActiveChange(false),
+        onTapUp: (_) => handleActiveChange(false),
+        onTapCancel: () => handleActiveChange(false),
         child: AbsorbPointer(
           child: child,
         ),
@@ -274,14 +274,14 @@ abstract class YaruTogglableState<S extends YaruTogglable> extends State<S>
                   size: togglableSize,
                   painter: painter
                     ..interactive = widget.interactive
-                    ..hover = _hover
-                    ..focus = _focus
-                    ..active = _active
+                    ..hover = hover
+                    ..focus = focus
+                    ..active = active
                     ..checked = widget.checked
-                    ..oldChecked = _oldChecked
-                    ..position = _position
-                    ..sizePosition = _sizePosition
-                    ..indicatorPosition = _indicatorPosition
+                    ..oldChecked = oldChecked
+                    ..position = position
+                    ..sizePosition = sizePosition
+                    ..indicatorPosition = indicatorPosition
                     ..uncheckedColor = uncheckedColor
                     ..uncheckedBorderColor = uncheckedBorderColor
                     ..checkedColor = checkedColor


### PR DESCRIPTION
- The drag zone is located in the dot region ;
- I exposed important private properties and method of the abstract `YaruTogglableState` class, so descendent classes can access to them ;
- The `MouseRegion` is removed with a disabled switch.

[Capture vidéo du 2023-01-28 17-22-43.webm](https://user-images.githubusercontent.com/36476595/215277684-26d72f52-f60d-4823-9930-5405af900cfc.webm)

Fixes #405

## Pull request checklist

- [x] This PR does not introduce visual changes