### PR TITLE
YaruTitleBar: set an opaque background when the window is inactive

### DIFF
--- a/lib/src/widgets/yaru_title_bar.dart
+++ b/lib/src/widgets/yaru_title_bar.dart
@@ -135,7 +135,7 @@ class YaruTitleBar extends StatelessWidget implements PreferredSizeWidget {
     };
     final defaultBackgroundColor = MaterialStateProperty.resolveWith((states) {
       if (!states.contains(MaterialState.focused)) {
-        return Colors.transparent;
+        return theme.colorScheme.background;
       }
       return light ? YaruColors.titleBarLight : YaruColors.titleBarDark;
     });


### PR DESCRIPTION
Fixes: #577

## Pull request checklist

- [x] This PR does not introduce visual changes, **or**
  - I ran `flutter test --update-goldens` and committed the changes if there were any, **or**
  - I added before/after/light/dark screenshots if the visual changes I made were not covered by golden tests.
    | |Before|After|
    |-|-|-|
    |Light| ![Screenshot from 2023-02-05 22-57-46](https://user-images.githubusercontent.com/140617/216848361-88c42f7e-267a-4708-ba7d-79e39bbbb1cd.png) | ![Screenshot from 2023-02-05 22-57-29](https://user-images.githubusercontent.com/140617/216848366-c63bdd04-55b8-46b0-8ba5-2a442e007511.png) |
    |Dark| ![Screenshot from 2023-02-05 22-56-45](https://user-images.githubusercontent.com/140617/216848378-217b62eb-90b8-4e95-bbd7-f050ede4b596.png) | ![Screenshot from 2023-02-05 22-57-11](https://user-images.githubusercontent.com/140617/216848373-e51b20ba-21a9-4565-b50f-ae58081aa5f4.png) |