### PR TITLE
Pass curve parameter to next/previousPage methods

### DIFF
--- a/lib/src/widgets/yaru_carousel.dart
+++ b/lib/src/widgets/yaru_carousel.dart
@@ -289,7 +289,7 @@ class YaruCarouselController extends PageController {
   Future<void> nextPage({Duration? duration, Curve? curve}) {
     return super.nextPage(
       duration: duration ?? scrollAnimationDuration,
-      curve: scrollAnimationCurve,
+      curve: curve ?? scrollAnimationCurve,
     );
   }
 
@@ -297,7 +297,7 @@ class YaruCarouselController extends PageController {
   Future<void> previousPage({Duration? duration, Curve? curve}) {
     return super.previousPage(
       duration: duration ?? scrollAnimationDuration,
-      curve: scrollAnimationCurve,
+      curve: curve ?? scrollAnimationCurve,
     );
   }
 


### PR DESCRIPTION
I don't know whyn but the `curve` parameter was passed to `nextPage` and `previousPage` methods.

## Pull request checklist

- [x] This PR does not introduce visual changes