### PR TITLE
pubspec.yaml: clean up `uses-material-design: true`

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,6 +23,3 @@ dev_dependencies:
     sdk: flutter
   golden_toolkit: ^0.13.0
   test: ^1.21.4
-
-flutter:
-  uses-material-design: true


### PR DESCRIPTION
Probably a leftover from the app template. The package was generated without passing "--template package" so Flutter generated a pubspec for an app.

Fixes: #607