### PR TITLE
YaruPageIndicator: add custom scale parameters

### DIFF
--- a/example/lib/pages/page_indicator.dart
+++ b/example/lib/pages/page_indicator.dart
@@ -12,8 +12,8 @@ class PageIndicatorPage extends StatefulWidget {
 class _PageIndicatorPageState extends State<PageIndicatorPage> {
   int _page = 0;
   int _length = 5;
-  double _dotSizeFactor = 1.0;
-  double _dotSpacingFactor = 1.0;
+  double _dotSize = 12.0;
+  double _dotSpacing = 48.0;
 
   @override
   Widget build(BuildContext context) {
@@ -24,8 +24,8 @@ class _PageIndicatorPageState extends State<PageIndicatorPage> {
           length: _length,
           page: _page,
           onTap: (page) => setState(() => _page = page),
-          dotSizeFactor: _dotSizeFactor,
-          dotSpacingFactor: _dotSpacingFactor,
+          dotSize: _dotSize,
+          dotSpacing: _dotSpacing,
         ),
         const SizedBox(height: 15),
         ButtonBar(
@@ -50,16 +50,16 @@ class _PageIndicatorPageState extends State<PageIndicatorPage> {
           ],
         ),
         Slider(
-          min: 0.5,
-          max: 2,
-          value: _dotSizeFactor,
-          onChanged: (scale) => setState(() => _dotSizeFactor = scale),
+          min: 6.0,
+          max: 24.0,
+          value: _dotSize,
+          onChanged: (scale) => setState(() => _dotSize = scale),
         ),
         Slider(
-          min: 0.5,
-          max: 2,
-          value: _dotSpacingFactor,
-          onChanged: (scale) => setState(() => _dotSpacingFactor = scale),
+          min: 12.0,
+          max: 96.0,
+          value: _dotSpacing,
+          onChanged: (scale) => setState(() => _dotSpacing = scale),
         ),
       ],
     );

--- a/example/lib/pages/page_indicator.dart
+++ b/example/lib/pages/page_indicator.dart
@@ -12,6 +12,8 @@ class PageIndicatorPage extends StatefulWidget {
 class _PageIndicatorPageState extends State<PageIndicatorPage> {
   int _page = 0;
   int _length = 5;
+  double _dotSizeFactor = 1.0;
+  double _dotSpacingFactor = 1.0;
 
   @override
   Widget build(BuildContext context) {
@@ -22,6 +24,8 @@ class _PageIndicatorPageState extends State<PageIndicatorPage> {
           length: _length,
           page: _page,
           onTap: (page) => setState(() => _page = page),
+          dotSizeFactor: _dotSizeFactor,
+          dotSpacingFactor: _dotSpacingFactor,
         ),
         const SizedBox(height: 15),
         ButtonBar(
@@ -44,7 +48,19 @@ class _PageIndicatorPageState extends State<PageIndicatorPage> {
               child: const Icon(YaruIcons.minus),
             )
           ],
-        )
+        ),
+        Slider(
+          min: 0.5,
+          max: 2,
+          value: _dotSizeFactor,
+          onChanged: (scale) => setState(() => _dotSizeFactor = scale),
+        ),
+        Slider(
+          min: 0.5,
+          max: 2,
+          value: _dotSpacingFactor,
+          onChanged: (scale) => setState(() => _dotSpacingFactor = scale),
+        ),
       ],
     );
   }

--- a/lib/src/widgets/yaru_page_indicator.dart
+++ b/lib/src/widgets/yaru_page_indicator.dart
@@ -19,8 +19,8 @@ class YaruPageIndicator extends StatelessWidget {
     this.animationDuration = Duration.zero,
     this.animationCurve = Curves.linear,
     this.onTap,
-    this.dotSizeFactor = 1.0,
-    this.dotSpacingFactor = 1.0,
+    this.dotSize = 12.0,
+    this.dotSpacing = 48.0,
   }) : assert(page >= 0 && page <= length - 1);
 
   /// Determine the number of pages.
@@ -41,25 +41,24 @@ class YaruPageIndicator extends StatelessWidget {
   /// It passes the tapped page index as parameter.
   final ValueChanged<int>? onTap;
 
-  /// Scaling factor that controls the size of the dots.
-  final double dotSizeFactor;
+  /// Size of the dots.
+  final double dotSize;
 
-  /// Scaling factor that controls the spacing of the dots.
-  final double dotSpacingFactor;
+  /// Base length for the space between the dots.
+  /// Will be automatically reduced to fit the vertical constraints.
+  final double dotSpacing;
 
   @override
   Widget build(BuildContext context) {
     return LayoutBuilder(
       builder: (context, constraints) {
-        final dotSize = 12.0 * dotSizeFactor;
-
         for (final layout in [
-          [48.0, constraints.maxWidth / 2],
-          [24.0, constraints.maxWidth / 3 * 2],
-          [12.0, constraints.maxWidth / 6 * 5]
+          [dotSpacing, constraints.maxWidth / 2],
+          [dotSpacing / 2, constraints.maxWidth / 3 * 2],
+          [dotSpacing / 4, constraints.maxWidth / 6 * 5]
         ]) {
-          final dotSpacing = layout[0] * dotSpacingFactor;
-          final maxWidth = layout[1] * dotSpacingFactor;
+          final dotSpacing = layout[0];
+          final maxWidth = layout[1];
 
           if (dotSize * length + dotSpacing * (length - 1) < maxWidth) {
             return _buildDotIndicator(context, dotSize, dotSpacing);

--- a/lib/src/widgets/yaru_page_indicator.dart
+++ b/lib/src/widgets/yaru_page_indicator.dart
@@ -19,6 +19,8 @@ class YaruPageIndicator extends StatelessWidget {
     this.animationDuration = Duration.zero,
     this.animationCurve = Curves.linear,
     this.onTap,
+    this.dotSizeFactor = 1.0,
+    this.dotSpacingFactor = 1.0,
   }) : assert(page >= 0 && page <= length - 1);
 
   /// Determine the number of pages.
@@ -39,19 +41,25 @@ class YaruPageIndicator extends StatelessWidget {
   /// It passes the tapped page index as parameter.
   final ValueChanged<int>? onTap;
 
+  /// Scaling factor that controls the size of the dots.
+  final double dotSizeFactor;
+
+  /// Scaling factor that controls the spacing of the dots.
+  final double dotSpacingFactor;
+
   @override
   Widget build(BuildContext context) {
     return LayoutBuilder(
       builder: (context, constraints) {
-        const dotSize = 12.0;
+        final dotSize = 12.0 * dotSizeFactor;
 
         for (final layout in [
           [48.0, constraints.maxWidth / 2],
           [24.0, constraints.maxWidth / 3 * 2],
           [12.0, constraints.maxWidth / 6 * 5]
         ]) {
-          final dotSpacing = layout[0];
-          final maxWidth = layout[1];
+          final dotSpacing = layout[0] * dotSpacingFactor;
+          final maxWidth = layout[1] * dotSpacingFactor;
 
           if (dotSize * length + dotSpacing * (length - 1) < maxWidth) {
             return _buildDotIndicator(context, dotSize, dotSpacing);


### PR DESCRIPTION
Allows to customize the size and spacing of `YaruPageIndicator`'s dots:

[Screencast from 2023-02-22 12-48-53.webm](https://user-images.githubusercontent.com/113362648/220611821-6b85ab12-973f-463e-bf70-383df1521b2e.webm)

Fix #622

## Pull request checklist

- [x] This PR does not introduce visual changes, **or**
  - I ran `flutter test --update-goldens` and committed the changes if there were any, **or**
  - I added before/after/light/dark screenshots if the visual changes I made were not covered by golden tests.
    | |Before|After|
    |-|-|-|
    |Light| | |
    |Dark| | |