### PR TITLE
`YaruPortraitLayout`: add missing hero controller

### DIFF
--- a/lib/src/widgets/master_detail/yaru_portrait_layout.dart
+++ b/lib/src/widgets/master_detail/yaru_portrait_layout.dart
@@ -117,6 +117,7 @@ class _YaruPortraitLayoutState extends State<YaruPortraitLayout> {
             ),
             if (_selectedIndex != -1) page(_selectedIndex)
           ],
+          observers: [HeroController()],
         ),
       ),
     );


### PR DESCRIPTION
It should also have one, just like `YaruLandscapeLayout` and `YaruNavigationPage` do.

<!-- REMINDER: If this PR introduces any visual changes, please run:
```
flutter test --update-goldens
```
and commit the changes **or** if not covered by tests, attach screenshots below:

|       | Before | After |
|-------|--------|-------|
| Light |        |       |
| Dark  |        |       |

-->
