### PR TITLE
Update PR template for the new branch organization

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!-- REMINDER:
 
-1) For a bug fix, please target the latest `2.x` branch, else target `main`.
+1) For a bug fix, please target the `release` branch, else target `main`.
 
 2) If this PR introduces any visual changes, please run:
 ```

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,8 @@
-<!-- REMINDER: If this PR introduces any visual changes, please run:
+<!-- REMINDER:
+
+1) For a bug fix, please target `2.1.x` branch, else target `main`.
+
+2) If this PR introduces any visual changes, please run:
 ```
 flutter test --update-goldens
 ```

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!-- REMINDER:
 
-1) For a bug fix, please target `2.1.x` branch, else target `main`.
+1) For a bug fix, please target the latest `2.x` branch, else target `main`.
 
 2) If this PR introduces any visual changes, please run:
 ```


### PR DESCRIPTION
Update the PR template for the new branch organization.

For reminder:
- now `main` is for the development of the new features ;
- a new `2.1.x` branch will be created after this PR being merged, based on `main`, for every bug fixes.

Then, I'll create a PR to cherry-pick the only commit from `2.2-dev` to `main`.