### PR TITLE
Add YaruSelectableContainer.mouseCursor

### DIFF
--- a/lib/src/widgets/yaru_selectable_container.dart
+++ b/lib/src/widgets/yaru_selectable_container.dart
@@ -15,6 +15,7 @@ class YaruSelectableContainer extends StatelessWidget {
     this.radius = kYaruContainerRadius,
     this.padding,
     this.selectionColor,
+    this.mouseCursor,
   });
 
   // The child which will be selected with [onTap]
@@ -42,6 +43,9 @@ class YaruSelectableContainer extends StatelessWidget {
   /// Optional custom [Color] which is used for the selection border.
   final Color? selectionColor;
 
+  /// The cursor for a mouse pointer when it enters or is hovering over the widget.
+  final MouseCursor? mouseCursor;
+
   @override
   Widget build(BuildContext context) {
     final padding = this.padding ?? const EdgeInsets.all(6);
@@ -50,6 +54,7 @@ class YaruSelectableContainer extends StatelessWidget {
     return InkWell(
       borderRadius: borderRadius,
       onTap: onTap,
+      mouseCursor: mouseCursor,
       child: AnimatedContainer(
         duration: _kAnimationDuration,
         decoration: BoxDecoration(


### PR DESCRIPTION
There's no visual change by default but this makes it possible to change the mouse cursor to anything, such as `SystemMouseCursors.basic`.

| Before | After |
|---|---|
| ![Screenshot from 2023-03-05 13-31-49](https://user-images.githubusercontent.com/140617/222960743-1fe2b941-6e6a-4d9e-b25e-030da69b186f.png) | ![image](https://user-images.githubusercontent.com/140617/222960725-e2847513-d60a-4d2a-969f-d2f9818162de.png) |

Ref: ubuntu/yaru.dart#85
Ref: canonical/ubuntu-desktop-installer#1532