### PR TITLE
widgets.dart: add missing export yaru_page_indicator_theme.dart

### DIFF
--- a/lib/widgets.dart
+++ b/lib/widgets.dart
@@ -26,6 +26,7 @@ export 'src/widgets/yaru_icon_button.dart';
 export 'src/widgets/yaru_linear_progress_indicator.dart';
 export 'src/widgets/yaru_option_button.dart';
 export 'src/widgets/yaru_page_indicator.dart';
+export 'src/widgets/yaru_page_indicator_theme.dart';
 export 'src/widgets/yaru_popup_menu_button.dart';
 export 'src/widgets/yaru_radio.dart';
 export 'src/widgets/yaru_radio_button.dart';


### PR DESCRIPTION
<!-- REMINDER:

1) For a bug fix, please target the `release` branch, else target `main`.

2) If this PR introduces any visual changes, please run:
```
flutter test --update-goldens
```
and commit the changes **or** if not covered by tests, attach screenshots below:

|       | Before | After |
|-------|--------|-------|
| Light |        |       |
| Dark  |        |       |

-->
