### PR TITLE
Add YaruPageIndicator(ThemeData).mouseCursor

### DIFF
--- a/lib/src/widgets/yaru_page_indicator.dart
+++ b/lib/src/widgets/yaru_page_indicator.dart
@@ -29,6 +29,7 @@ class YaruPageIndicator extends StatelessWidget {
     this.dotSize,
     this.dotSpacing,
     this.dotDecorationBuilder,
+    this.mouseCursor,
   }) : assert(page >= 0 && page <= length - 1);
 
   /// Determine the number of pages.
@@ -66,6 +67,9 @@ class YaruPageIndicator extends StatelessWidget {
 
   /// Decoration of the dots.
   final YaruDotDecorationBuilder? dotDecorationBuilder;
+
+  /// The cursor for a mouse pointer when it enters or is hovering over the widget.
+  final MouseCursor? mouseCursor;
 
   @override
   Widget build(BuildContext context) {
@@ -113,6 +117,10 @@ class YaruPageIndicator extends StatelessWidget {
         Duration.zero;
     final animationCurve =
         this.animationCurve ?? indicatorTheme?.animationCurve ?? Curves.linear;
+    final mouseCursor = this.mouseCursor ??
+        indicatorTheme?.mouseCursor
+            ?.resolve({if (onTap == null) MaterialState.disabled}) ??
+        (onTap == null ? SystemMouseCursors.basic : SystemMouseCursors.click);
 
     return Row(
       mainAxisAlignment: MainAxisAlignment.center,
@@ -132,9 +140,7 @@ class YaruPageIndicator extends StatelessWidget {
           child: Padding(
             padding: EdgeInsets.only(left: index != 0 ? dotSpacing : 0),
             child: MouseRegion(
-              cursor: onTap == null
-                  ? SystemMouseCursors.basic
-                  : SystemMouseCursors.click,
+              cursor: mouseCursor,
               child: animationDuration == Duration.zero
                   ? Container(
                       width: dotSize,

--- a/lib/src/widgets/yaru_page_indicator_theme.dart
+++ b/lib/src/widgets/yaru_page_indicator_theme.dart
@@ -20,6 +20,7 @@ class YaruPageIndicatorThemeData
     this.dotSize,
     this.dotSpacing,
     this.dotDecorationBuilder,
+    this.mouseCursor,
   });
 
   /// Duration of a transition between two items.
@@ -39,6 +40,9 @@ class YaruPageIndicatorThemeData
   /// Decoration of the dots.
   final YaruDotDecorationBuilder? dotDecorationBuilder;
 
+  /// The cursor for a mouse pointer when it enters or is hovering over the widget.
+  final MaterialStateProperty<MouseCursor?>? mouseCursor;
+
   /// Creates a copy with the given fields replaced with new values.
   @override
   YaruPageIndicatorThemeData copyWith({
@@ -47,6 +51,7 @@ class YaruPageIndicatorThemeData
     double? dotSize,
     double? dotSpacing,
     YaruDotDecorationBuilder? dotDecorationBuilder,
+    MaterialStateProperty<MouseCursor?>? mouseCursor,
   }) {
     return YaruPageIndicatorThemeData(
       animationDuration: animationDuration ?? this.animationDuration,
@@ -54,6 +59,7 @@ class YaruPageIndicatorThemeData
       dotSize: dotSize ?? this.dotSize,
       dotSpacing: dotSpacing ?? this.dotSpacing,
       dotDecorationBuilder: dotDecorationBuilder ?? this.dotDecorationBuilder,
+      mouseCursor: mouseCursor ?? this.mouseCursor,
     );
   }
 
@@ -74,6 +80,7 @@ class YaruPageIndicatorThemeData
       dotSpacing: lerpDouble(dotSpacing, o?.dotSpacing, t),
       dotDecorationBuilder:
           t < 0.5 ? dotDecorationBuilder : o?.dotDecorationBuilder,
+      mouseCursor: t < 0.5 ? mouseCursor : o?.mouseCursor,
     );
   }
 
@@ -85,6 +92,7 @@ class YaruPageIndicatorThemeData
       dotSize,
       dotSpacing,
       dotDecorationBuilder,
+      mouseCursor,
     );
   }
 
@@ -97,7 +105,8 @@ class YaruPageIndicatorThemeData
         other.animationCurve == animationCurve &&
         other.dotSize == dotSize &&
         other.dotSpacing == dotSpacing &&
-        other.dotDecorationBuilder == dotDecorationBuilder;
+        other.dotDecorationBuilder == dotDecorationBuilder &&
+        other.mouseCursor == mouseCursor;
   }
 }
 


### PR DESCRIPTION
There's no visual change by default but this makes it possible to change the mouse cursor to anything, such as `SystemMouseCursors.basic`.

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/140617/222961772-a206c618-86b1-4fe3-b353-10a47d6de351.png) | ![image](https://user-images.githubusercontent.com/140617/222961804-8698f5bd-dc71-4d19-bb77-478cfa48f68f.png) |

Ref: ubuntu/yaru.dart#85
Ref: canonical/ubuntu-desktop-installer#1532