### PR TITLE
Add YaruPopupMenuButton.mouseCursor

### DIFF
--- a/lib/src/widgets/yaru_popup_menu_button.dart
+++ b/lib/src/widgets/yaru_popup_menu_button.dart
@@ -23,6 +23,7 @@ class YaruPopupMenuButton<T> extends StatelessWidget {
     this.constraints,
     this.elevation,
     this.style,
+    this.mouseCursor,
   });
 
   final T? initialValue;
@@ -40,6 +41,7 @@ class YaruPopupMenuButton<T> extends StatelessWidget {
   final BoxConstraints? constraints;
   final double? elevation;
   final ButtonStyle? style;
+  final MouseCursor? mouseCursor;
 
   @override
   Widget build(BuildContext context) {
@@ -52,6 +54,11 @@ class YaruPopupMenuButton<T> extends StatelessWidget {
             color: Theme.of(context).colorScheme.outline,
           ),
         );
+    final mouseCursor = this.mouseCursor ??
+        style?.mouseCursor?.resolve(state) ??
+        (onSelected != null
+            ? SystemMouseCursors.click
+            : SystemMouseCursors.basic);
     return DecoratedBox(
       decoration: ShapeDecoration(shape: shape.copyWith(side: side)),
       child: Material(
@@ -71,31 +78,34 @@ class YaruPopupMenuButton<T> extends StatelessWidget {
           offset: offset,
           enableFeedback: enableFeedback,
           constraints: constraints,
-          child: Opacity(
-            opacity: enabled ? 1 : 0.38,
-            child: Padding(
-              padding: padding,
-              child: DefaultTextStyle(
-                style: TextStyle(
-                  color: Theme.of(context).colorScheme.onSurface,
-                  fontWeight: FontWeight.w500,
-                ),
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    Padding(
-                      padding: childPadding,
-                      child: child,
-                    ),
-                    const SizedBox(
-                      height: 40,
-                      child: Icon(
-                        YaruIcons.pan_down,
-                        size: 20,
+          child: MouseRegion(
+            cursor: mouseCursor,
+            child: Opacity(
+              opacity: enabled ? 1 : 0.38,
+              child: Padding(
+                padding: padding,
+                child: DefaultTextStyle(
+                  style: TextStyle(
+                    color: Theme.of(context).colorScheme.onSurface,
+                    fontWeight: FontWeight.w500,
+                  ),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Padding(
+                        padding: childPadding,
+                        child: child,
                       ),
-                    ),
-                  ],
+                      const SizedBox(
+                        height: 40,
+                        child: Icon(
+                          YaruIcons.pan_down,
+                          size: 20,
+                        ),
+                      ),
+                    ],
+                  ),
                 ),
               ),
             ),


### PR DESCRIPTION
There's no visual change by default but this makes it possible to change the mouse cursor to anything, such as `SystemMouseCursors.basic`.

Ref: ubuntu/yaru.dart#85
Ref: canonical/ubuntu-desktop-installer#1532