### PR TITLE
YaruColorDisk: add subtle hover & focus highlight

### DIFF
--- a/lib/src/widgets/yaru_color_disk.dart
+++ b/lib/src/widgets/yaru_color_disk.dart
@@ -19,15 +19,27 @@ class YaruColorDisk extends StatelessWidget {
       child: Padding(
         padding: const EdgeInsets.all(8.0),
         child: TextButton(
-          style: TextButton.styleFrom(
-            padding: EdgeInsets.zero,
-            shape: CircleBorder(
-              side: BorderSide(
-                color: selected
-                    ? Theme.of(context).primaryColor
-                    : Colors.transparent,
-              ),
-            ),
+          statesController: MaterialStatesController({
+            if (selected) MaterialState.selected,
+          }),
+          style: ButtonStyle(
+            overlayColor: MaterialStateProperty.all(Colors.transparent),
+            padding: ButtonStyleButton.allOrNull(EdgeInsets.zero),
+            shape: MaterialStateProperty.resolveWith<OutlinedBorder?>((states) {
+              return CircleBorder(
+                side: BorderSide(
+                  color: color.withOpacity(
+                    states.contains(MaterialState.selected) ||
+                            states.contains(MaterialState.pressed)
+                        ? 1.0
+                        : states.contains(MaterialState.hovered) ||
+                                states.contains(MaterialState.focused)
+                            ? 0.5
+                            : 0,
+                  ),
+                ),
+              );
+            }),
           ),
           onPressed: onPressed,
           child: SizedBox(


### PR DESCRIPTION
Helps to give it an interactive feeling if the pointing finger mouse cursor is turned to a basic cursor for a more desktop'ish feeling.

[Screencast from 2023-03-05 16-36-50.webm](https://user-images.githubusercontent.com/140617/222970347-17336401-9994-400a-83d0-cefc66c7a6f3.webm)
