### PR TITLE
Resolve mouse cursor widget properties

### DIFF
--- a/lib/src/widgets/yaru_check_button.dart
+++ b/lib/src/widgets/yaru_check_button.dart
@@ -49,10 +49,12 @@ class YaruCheckButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final mouseCursor = this.mouseCursor ??
-        YaruToggleButtonTheme.of(context)
-            ?.mouseCursor
-            ?.resolve({if (onChanged == null) MaterialState.disabled});
+    final states = {
+      if (onChanged == null) MaterialState.disabled,
+    };
+    final mouseCursor =
+        MaterialStateProperty.resolveAs(this.mouseCursor, states) ??
+            YaruToggleButtonTheme.of(context)?.mouseCursor?.resolve(states);
 
     return YaruToggleButton(
       title: title,
@@ -66,10 +68,8 @@ class YaruCheckButton extends StatelessWidget {
         autofocus: autofocus,
         mouseCursor: mouseCursor,
       ),
-      mouseCursor: mouseCursor ??
-          (onChanged != null
-              ? SystemMouseCursors.click
-              : SystemMouseCursors.basic),
+      mouseCursor:
+          mouseCursor ?? MaterialStateMouseCursor.clickable.resolve(states),
       onToggled: onChanged == null ? null : _onToggled,
     );
   }

--- a/lib/src/widgets/yaru_page_indicator.dart
+++ b/lib/src/widgets/yaru_page_indicator.dart
@@ -117,10 +117,13 @@ class YaruPageIndicator extends StatelessWidget {
         Duration.zero;
     final animationCurve =
         this.animationCurve ?? indicatorTheme?.animationCurve ?? Curves.linear;
-    final mouseCursor = this.mouseCursor ??
-        indicatorTheme?.mouseCursor
-            ?.resolve({if (onTap == null) MaterialState.disabled}) ??
-        (onTap == null ? SystemMouseCursors.basic : SystemMouseCursors.click);
+    final states = {
+      if (onTap == null) MaterialState.disabled,
+    };
+    final mouseCursor =
+        MaterialStateProperty.resolveAs(this.mouseCursor, states) ??
+            indicatorTheme?.mouseCursor?.resolve(states) ??
+            MaterialStateMouseCursor.clickable.resolve(states);
 
     return Row(
       mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/src/widgets/yaru_popup_menu_button.dart
+++ b/lib/src/widgets/yaru_popup_menu_button.dart
@@ -54,11 +54,10 @@ class YaruPopupMenuButton<T> extends StatelessWidget {
             color: Theme.of(context).colorScheme.outline,
           ),
         );
-    final mouseCursor = this.mouseCursor ??
-        style?.mouseCursor?.resolve(state) ??
-        (onSelected != null
-            ? SystemMouseCursors.click
-            : SystemMouseCursors.basic);
+    final mouseCursor =
+        MaterialStateProperty.resolveAs(this.mouseCursor, state) ??
+            style?.mouseCursor?.resolve(state) ??
+            MaterialStateMouseCursor.clickable.resolve(state);
     return DecoratedBox(
       decoration: ShapeDecoration(shape: shape.copyWith(side: side)),
       child: Material(

--- a/lib/src/widgets/yaru_radio_button.dart
+++ b/lib/src/widgets/yaru_radio_button.dart
@@ -53,10 +53,12 @@ class YaruRadioButton<T> extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final mouseCursor = this.mouseCursor ??
-        YaruToggleButtonTheme.of(context)
-            ?.mouseCursor
-            ?.resolve({if (onChanged == null) MaterialState.disabled});
+    final states = {
+      if (onChanged == null) MaterialState.disabled,
+    };
+    final mouseCursor =
+        MaterialStateProperty.resolveAs(this.mouseCursor, states) ??
+            YaruToggleButtonTheme.of(context)?.mouseCursor?.resolve(states);
 
     return YaruToggleButton(
       title: title,
@@ -71,10 +73,8 @@ class YaruRadioButton<T> extends StatelessWidget {
         autofocus: autofocus,
         mouseCursor: mouseCursor,
       ),
-      mouseCursor: mouseCursor ??
-          (onChanged != null
-              ? SystemMouseCursors.click
-              : SystemMouseCursors.basic),
+      mouseCursor:
+          mouseCursor ?? MaterialStateMouseCursor.clickable.resolve(states),
       onToggled: onChanged == null ? null : _onToggled,
     );
   }

--- a/lib/src/widgets/yaru_switch_button.dart
+++ b/lib/src/widgets/yaru_switch_button.dart
@@ -45,10 +45,12 @@ class YaruSwitchButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final mouseCursor = this.mouseCursor ??
-        YaruToggleButtonTheme.of(context)
-            ?.mouseCursor
-            ?.resolve({if (onChanged == null) MaterialState.disabled});
+    final states = {
+      if (onChanged == null) MaterialState.disabled,
+    };
+    final mouseCursor =
+        MaterialStateProperty.resolveAs(this.mouseCursor, states) ??
+            YaruToggleButtonTheme.of(context)?.mouseCursor?.resolve(states);
 
     return YaruToggleButton(
       title: title,
@@ -61,10 +63,8 @@ class YaruSwitchButton extends StatelessWidget {
         autofocus: autofocus,
         mouseCursor: mouseCursor,
       ),
-      mouseCursor: mouseCursor ??
-          (onChanged != null
-              ? SystemMouseCursors.click
-              : SystemMouseCursors.basic),
+      mouseCursor:
+          mouseCursor ?? MaterialStateMouseCursor.clickable.resolve(states),
       onToggled: onChanged != null ? () => onChanged!(!value) : null,
     );
   }

--- a/lib/src/widgets/yaru_toggle_button.dart
+++ b/lib/src/widgets/yaru_toggle_button.dart
@@ -44,16 +44,19 @@ class YaruToggleButton extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = YaruToggleButtonTheme.of(context);
     final textTheme = Theme.of(context).textTheme;
+    final states = {
+      if (onToggled == null) MaterialState.disabled,
+    };
+    final mouseCursor =
+        MaterialStateProperty.resolveAs(this.mouseCursor, states) ??
+            MaterialStateMouseCursor.clickable.resolve(states);
 
     return MergeSemantics(
       child: Semantics(
         child: GestureDetector(
           onTap: onToggled,
           child: MouseRegion(
-            cursor: mouseCursor ??
-                (onToggled != null
-                    ? SystemMouseCursors.click
-                    : SystemMouseCursors.basic),
+            cursor: mouseCursor,
             child: Padding(
               padding: contentPadding ?? EdgeInsets.zero,
               child: _YaruToggleButtonLayout(


### PR DESCRIPTION
I was looking at some old Flutter PRs for themable mouse cursors and noticed that the `MouseCursor` type of widget properties were not used "as is" but also resolved against the widget state with help of `MaterialStateProperty.resolveAs`. The Flutter team recommended doing it this way to support `MaterialStateMouseCursor` in place of `MouseCursor`.