### PR TITLE
YaruTogglable: add states controller

### DIFF
--- a/lib/src/widgets/yaru_checkbox.dart
+++ b/lib/src/widgets/yaru_checkbox.dart
@@ -51,6 +51,7 @@ class YaruCheckbox extends StatefulWidget implements YaruTogglable<bool?> {
     this.focusNode,
     this.autofocus = false,
     this.mouseCursor,
+    this.statesController,
   }) : assert(tristate || value != null);
 
   /// Whether this checkbox is checked.
@@ -128,6 +129,9 @@ class YaruCheckbox extends StatefulWidget implements YaruTogglable<bool?> {
 
   @override
   final MouseCursor? mouseCursor;
+
+  @override
+  final MaterialStatesController? statesController;
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {

--- a/lib/src/widgets/yaru_radio.dart
+++ b/lib/src/widgets/yaru_radio.dart
@@ -50,6 +50,7 @@ class YaruRadio<T> extends StatefulWidget implements YaruTogglable<T?> {
     this.focusNode,
     this.autofocus = false,
     this.mouseCursor,
+    this.statesController,
   }) : assert(toggleable || value != null);
 
   /// The value represented by this radio button.
@@ -138,6 +139,9 @@ class YaruRadio<T> extends StatefulWidget implements YaruTogglable<T?> {
 
   @override
   final MouseCursor? mouseCursor;
+
+  @override
+  final MaterialStatesController? statesController;
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {

--- a/lib/src/widgets/yaru_switch.dart
+++ b/lib/src/widgets/yaru_switch.dart
@@ -42,6 +42,7 @@ class YaruSwitch extends StatefulWidget implements YaruTogglable<bool> {
     this.focusNode,
     this.autofocus = false,
     this.mouseCursor,
+    this.statesController,
   });
 
   /// Whether this switch is on or off.
@@ -104,6 +105,9 @@ class YaruSwitch extends StatefulWidget implements YaruTogglable<bool> {
 
   @override
   final MouseCursor? mouseCursor;
+
+  @override
+  final MaterialStatesController? statesController;
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {

--- a/lib/src/widgets/yaru_togglable.dart
+++ b/lib/src/widgets/yaru_togglable.dart
@@ -26,6 +26,7 @@ abstract class YaruTogglable<T> extends StatefulWidget {
     this.focusNode,
     this.autofocus = false,
     this.mouseCursor,
+    this.statesController,
   });
 
   /// Value of this [YaruTogglable].
@@ -57,6 +58,9 @@ abstract class YaruTogglable<T> extends StatefulWidget {
 
   /// The cursor for a mouse pointer when it enters or is hovering over the widget.
   final MouseCursor? mouseCursor;
+
+  /// Controls the states of the [YaruTogglable].
+  final MaterialStatesController? statesController;
 }
 
 abstract class YaruTogglableState<S extends YaruTogglable> extends State<S>
@@ -74,6 +78,8 @@ abstract class YaruTogglableState<S extends YaruTogglable> extends State<S>
 
   late CurvedAnimation indicatorPosition;
   late AnimationController indicatorController;
+
+  late MaterialStatesController statesController;
 
   late final Map<Type, Action<Intent>> _actionMap = <Type, Action<Intent>>{
     ActivateIntent: CallbackAction<ActivateIntent>(onInvoke: handleTap),
@@ -117,6 +123,9 @@ abstract class YaruTogglableState<S extends YaruTogglable> extends State<S>
       parent: indicatorController,
       curve: Curves.fastOutSlowIn,
     );
+
+    statesController = widget.statesController ?? MaterialStatesController();
+    statesController.addListener(handleStateChange);
   }
 
   @override
@@ -145,6 +154,12 @@ abstract class YaruTogglableState<S extends YaruTogglable> extends State<S>
         sizeController.reverse();
       });
     }
+
+    if (oldWidget.statesController != widget.statesController) {
+      statesController.removeListener(handleStateChange);
+      statesController = widget.statesController ?? MaterialStatesController();
+      statesController.addListener(handleStateChange);
+    }
   }
 
   @override
@@ -152,8 +167,19 @@ abstract class YaruTogglableState<S extends YaruTogglable> extends State<S>
     positionController.dispose();
     indicatorController.dispose();
     sizeController.dispose();
+    statesController.removeListener(handleStateChange);
+    if (widget.statesController == null) {
+      statesController.dispose();
+    }
 
     super.dispose();
+  }
+
+  void handleStateChange() {
+    final states = statesController.value;
+    handleFocusChange(states.contains(MaterialState.focused));
+    handleHoverChange(states.contains(MaterialState.hovered));
+    handleActiveChange(states.contains(MaterialState.pressed));
   }
 
   void handleFocusChange(bool value) {
@@ -217,18 +243,22 @@ abstract class YaruTogglableState<S extends YaruTogglable> extends State<S>
       enabled: widget.interactive,
       focusNode: widget.focusNode,
       autofocus: widget.autofocus,
-      onShowFocusHighlight: handleFocusChange,
-      onShowHoverHighlight: handleHoverChange,
+      onShowFocusHighlight: (value) =>
+          statesController.update(MaterialState.focused, value),
+      onShowHoverHighlight: (value) =>
+          statesController.update(MaterialState.hovered, value),
       mouseCursor: mouseCursor ??
           (widget.interactive
               ? SystemMouseCursors.click
               : SystemMouseCursors.basic),
       child: GestureDetector(
         excludeFromSemantics: !widget.interactive,
-        onTapDown: (_) => handleActiveChange(widget.interactive),
+        onTapDown: (_) =>
+            statesController.update(MaterialState.pressed, widget.interactive),
         onTap: handleTap,
-        onTapUp: (_) => handleActiveChange(false),
-        onTapCancel: () => handleActiveChange(false),
+        onTapUp: (_) => statesController.update(MaterialState.pressed, false),
+        onTapCancel: () =>
+            statesController.update(MaterialState.pressed, false),
         child: AbsorbPointer(
           child: child,
         ),

--- a/lib/src/widgets/yaru_togglable.dart
+++ b/lib/src/widgets/yaru_togglable.dart
@@ -182,6 +182,10 @@ abstract class YaruTogglableState<S extends YaruTogglable> extends State<S>
     handleActiveChange(states.contains(MaterialState.pressed));
   }
 
+  void updateState(MaterialState state, bool add) {
+    statesController.update(state, add);
+  }
+
   void handleFocusChange(bool value) {
     if (focused == value) {
       return;
@@ -244,9 +248,9 @@ abstract class YaruTogglableState<S extends YaruTogglable> extends State<S>
       focusNode: widget.focusNode,
       autofocus: widget.autofocus,
       onShowFocusHighlight: (value) =>
-          statesController.update(MaterialState.focused, value),
+          updateState(MaterialState.focused, value),
       onShowHoverHighlight: (value) =>
-          statesController.update(MaterialState.hovered, value),
+          updateState(MaterialState.hovered, value),
       mouseCursor: mouseCursor ??
           (widget.interactive
               ? SystemMouseCursors.click
@@ -254,11 +258,10 @@ abstract class YaruTogglableState<S extends YaruTogglable> extends State<S>
       child: GestureDetector(
         excludeFromSemantics: !widget.interactive,
         onTapDown: (_) =>
-            statesController.update(MaterialState.pressed, widget.interactive),
+            updateState(MaterialState.pressed, widget.interactive),
         onTap: handleTap,
-        onTapUp: (_) => statesController.update(MaterialState.pressed, false),
-        onTapCancel: () =>
-            statesController.update(MaterialState.pressed, false),
+        onTapUp: (_) => updateState(MaterialState.pressed, false),
+        onTapCancel: () => updateState(MaterialState.pressed, false),
         child: AbsorbPointer(
           child: child,
         ),


### PR DESCRIPTION
Allows the surrounding `YaruToggleButton` to control the hovered state for its contained `YaruTogglable` when the label is hovered.

Inspired by Flutter's ButtonStyleButton, the base class of ElevatedButton, OutlinedButton, FilledButton, and TextButton:
https://api.flutter.dev/flutter/material/ButtonStyleButton/statesController.html

Ref: #659