### PR TITLE
Make YaruToggleButton subclasses stateful

### DIFF
--- a/lib/src/widgets/yaru_check_button.dart
+++ b/lib/src/widgets/yaru_check_button.dart
@@ -5,7 +5,7 @@ import 'yaru_toggle_button.dart';
 import 'yaru_toggle_button_theme.dart';
 
 /// A desktop style check button with an interactive label.
-class YaruCheckButton extends StatelessWidget {
+class YaruCheckButton extends StatefulWidget {
   /// Creates a new check button.
   const YaruCheckButton({
     super.key,
@@ -48,42 +48,47 @@ class YaruCheckButton extends StatelessWidget {
   final MouseCursor? mouseCursor;
 
   @override
+  State<YaruCheckButton> createState() => _YaruCheckButtonState();
+}
+
+class _YaruCheckButtonState extends State<YaruCheckButton> {
+  @override
   Widget build(BuildContext context) {
     final states = {
-      if (onChanged == null) MaterialState.disabled,
+      if (widget.onChanged == null) MaterialState.disabled,
     };
     final mouseCursor =
-        MaterialStateProperty.resolveAs(this.mouseCursor, states) ??
+        MaterialStateProperty.resolveAs(widget.mouseCursor, states) ??
             YaruToggleButtonTheme.of(context)?.mouseCursor?.resolve(states);
 
     return YaruToggleButton(
-      title: title,
-      subtitle: subtitle,
-      contentPadding: contentPadding,
+      title: widget.title,
+      subtitle: widget.subtitle,
+      contentPadding: widget.contentPadding,
       leading: YaruCheckbox(
-        value: value,
-        onChanged: onChanged,
-        tristate: tristate,
-        focusNode: focusNode,
-        autofocus: autofocus,
+        value: widget.value,
+        onChanged: widget.onChanged,
+        tristate: widget.tristate,
+        focusNode: widget.focusNode,
+        autofocus: widget.autofocus,
         mouseCursor: mouseCursor,
       ),
       mouseCursor:
           mouseCursor ?? MaterialStateMouseCursor.clickable.resolve(states),
-      onToggled: onChanged == null ? null : _onToggled,
+      onToggled: widget.onChanged == null ? null : _onToggled,
     );
   }
 
   void _onToggled() {
-    switch (value) {
+    switch (widget.value) {
       case false:
-        onChanged!(true);
+        widget.onChanged!(true);
         break;
       case true:
-        onChanged!(tristate ? null : false);
+        widget.onChanged!(widget.tristate ? null : false);
         break;
       case null:
-        onChanged!(false);
+        widget.onChanged!(false);
         break;
     }
   }

--- a/lib/src/widgets/yaru_radio_button.dart
+++ b/lib/src/widgets/yaru_radio_button.dart
@@ -5,7 +5,7 @@ import 'yaru_toggle_button.dart';
 import 'yaru_toggle_button_theme.dart';
 
 /// A desktop style radio button with an interactive label.
-class YaruRadioButton<T> extends StatelessWidget {
+class YaruRadioButton<T> extends StatefulWidget {
   /// Creates a new radio button.
   const YaruRadioButton({
     super.key,
@@ -52,38 +52,43 @@ class YaruRadioButton<T> extends StatelessWidget {
   final MouseCursor? mouseCursor;
 
   @override
+  State<YaruRadioButton<T>> createState() => _YaruRadioButtonState<T>();
+}
+
+class _YaruRadioButtonState<T> extends State<YaruRadioButton<T>> {
+  @override
   Widget build(BuildContext context) {
     final states = {
-      if (onChanged == null) MaterialState.disabled,
+      if (widget.onChanged == null) MaterialState.disabled,
     };
     final mouseCursor =
-        MaterialStateProperty.resolveAs(this.mouseCursor, states) ??
+        MaterialStateProperty.resolveAs(widget.mouseCursor, states) ??
             YaruToggleButtonTheme.of(context)?.mouseCursor?.resolve(states);
 
     return YaruToggleButton(
-      title: title,
-      subtitle: subtitle,
-      contentPadding: contentPadding,
+      title: widget.title,
+      subtitle: widget.subtitle,
+      contentPadding: widget.contentPadding,
       leading: YaruRadio<T>(
-        value: value,
-        groupValue: groupValue,
-        onChanged: onChanged,
-        toggleable: toggleable,
-        focusNode: focusNode,
-        autofocus: autofocus,
+        value: widget.value,
+        groupValue: widget.groupValue,
+        onChanged: widget.onChanged,
+        toggleable: widget.toggleable,
+        focusNode: widget.focusNode,
+        autofocus: widget.autofocus,
         mouseCursor: mouseCursor,
       ),
       mouseCursor:
           mouseCursor ?? MaterialStateMouseCursor.clickable.resolve(states),
-      onToggled: onChanged == null ? null : _onToggled,
+      onToggled: widget.onChanged == null ? null : _onToggled,
     );
   }
 
   void _onToggled() {
-    if (groupValue != value || !toggleable) {
-      onChanged!(value);
-    } else if (toggleable) {
-      onChanged!(null);
+    if (widget.groupValue != widget.value || !widget.toggleable) {
+      widget.onChanged!(widget.value);
+    } else if (widget.toggleable) {
+      widget.onChanged!(null);
     }
   }
 }

--- a/lib/src/widgets/yaru_switch_button.dart
+++ b/lib/src/widgets/yaru_switch_button.dart
@@ -5,7 +5,7 @@ import 'yaru_toggle_button.dart';
 import 'yaru_toggle_button_theme.dart';
 
 /// A desktop style switch button with an interactive label.
-class YaruSwitchButton extends StatelessWidget {
+class YaruSwitchButton extends StatefulWidget {
   /// Creates a new switch button.
   const YaruSwitchButton({
     super.key,
@@ -44,28 +44,35 @@ class YaruSwitchButton extends StatelessWidget {
   final MouseCursor? mouseCursor;
 
   @override
+  State<YaruSwitchButton> createState() => _YaruSwitchButtonState();
+}
+
+class _YaruSwitchButtonState extends State<YaruSwitchButton> {
+  @override
   Widget build(BuildContext context) {
     final states = {
-      if (onChanged == null) MaterialState.disabled,
+      if (widget.onChanged == null) MaterialState.disabled,
     };
     final mouseCursor =
-        MaterialStateProperty.resolveAs(this.mouseCursor, states) ??
+        MaterialStateProperty.resolveAs(widget.mouseCursor, states) ??
             YaruToggleButtonTheme.of(context)?.mouseCursor?.resolve(states);
 
     return YaruToggleButton(
-      title: title,
-      subtitle: subtitle,
-      contentPadding: contentPadding,
+      title: widget.title,
+      subtitle: widget.subtitle,
+      contentPadding: widget.contentPadding,
       leading: YaruSwitch(
-        value: value,
-        onChanged: onChanged,
-        focusNode: focusNode,
-        autofocus: autofocus,
+        value: widget.value,
+        onChanged: widget.onChanged,
+        focusNode: widget.focusNode,
+        autofocus: widget.autofocus,
         mouseCursor: mouseCursor,
       ),
       mouseCursor:
           mouseCursor ?? MaterialStateMouseCursor.clickable.resolve(states),
-      onToggled: onChanged != null ? () => onChanged!(!value) : null,
+      onToggled: widget.onChanged != null
+          ? () => widget.onChanged!(!widget.value)
+          : null,
     );
   }
 }


### PR DESCRIPTION
This is a noisy preparation step for #659 to make it possible for `YaruToggleButton` subclasses to create and dispose an internal `MaterialStatesController`.