### PR TITLE
YaruWatermark: ignore pointer for the watermark

### DIFF
--- a/lib/src/widgets/yaru_watermark.dart
+++ b/lib/src/widgets/yaru_watermark.dart
@@ -41,13 +41,15 @@ class YaruWatermark extends StatelessWidget {
     return Stack(
       children: [
         child,
-        Padding(
-          padding: padding,
-          child: Align(
-            alignment: alignment,
-            child: Opacity(
-              opacity: opacity,
-              child: watermark,
+        IgnorePointer(
+          child: Padding(
+            padding: padding,
+            child: Align(
+              alignment: alignment,
+              child: Opacity(
+                opacity: opacity,
+                child: watermark,
+              ),
             ),
           ),
         ),


### PR DESCRIPTION
Presumably, something called "watermark" is non-interactive and should therefore not block hover.

## Before

[Screencast from 2023-03-06 10-55-17.webm](https://user-images.githubusercontent.com/140617/223077234-a5b1a2b2-1a2d-4853-b10c-251c0cb9e7c4.webm)

## After

[Screencast from 2023-03-06 10-55-33.webm](https://user-images.githubusercontent.com/140617/223077293-bf6b5215-588e-4fdc-8c19-b41fdff504b9.webm)
