### PR TITLE
YaruPageIndicator: restore compatibility

### DIFF
--- a/example/lib/pages/page_indicator.dart
+++ b/example/lib/pages/page_indicator.dart
@@ -20,7 +20,7 @@ class _PageIndicatorPageState extends State<PageIndicatorPage> {
     return ListView(
       padding: const EdgeInsets.all(kYaruPagePadding),
       children: [
-        YaruPageIndicator.delegate(
+        YaruPageIndicator.builder(
           length: _length,
           page: _page,
           onTap: (page) => setState(() => _page = page),
@@ -34,7 +34,7 @@ class _PageIndicatorPageState extends State<PageIndicatorPage> {
           ),
         ),
         const SizedBox(height: 15),
-        YaruPageIndicator.delegate(
+        YaruPageIndicator.builder(
           length: _length,
           page: _page,
           onTap: (page) => setState(() => _page = page),

--- a/example/lib/pages/page_indicator.dart
+++ b/example/lib/pages/page_indicator.dart
@@ -20,7 +20,7 @@ class _PageIndicatorPageState extends State<PageIndicatorPage> {
     return ListView(
       padding: const EdgeInsets.all(kYaruPagePadding),
       children: [
-        YaruPageIndicator(
+        YaruPageIndicator.builder(
           length: _length,
           page: _page,
           onTap: (page) => setState(() => _page = page),
@@ -34,7 +34,7 @@ class _PageIndicatorPageState extends State<PageIndicatorPage> {
           ),
         ),
         const SizedBox(height: 15),
-        YaruPageIndicator(
+        YaruPageIndicator.builder(
           length: _length,
           page: _page,
           onTap: (page) => setState(() => _page = page),

--- a/example/lib/pages/page_indicator.dart
+++ b/example/lib/pages/page_indicator.dart
@@ -20,7 +20,7 @@ class _PageIndicatorPageState extends State<PageIndicatorPage> {
     return ListView(
       padding: const EdgeInsets.all(kYaruPagePadding),
       children: [
-        YaruPageIndicator.builder(
+        YaruPageIndicator.delegate(
           length: _length,
           page: _page,
           onTap: (page) => setState(() => _page = page),
@@ -34,7 +34,7 @@ class _PageIndicatorPageState extends State<PageIndicatorPage> {
           ),
         ),
         const SizedBox(height: 15),
-        YaruPageIndicator.builder(
+        YaruPageIndicator.delegate(
           length: _length,
           page: _page,
           onTap: (page) => setState(() => _page = page),

--- a/lib/src/widgets/yaru_carousel.dart
+++ b/lib/src/widgets/yaru_carousel.dart
@@ -116,7 +116,7 @@ class _YaruCarouselState extends State<YaruCarousel> {
             SizedBox(
               height: widget.placeIndicatorMarginTop,
             ),
-            YaruPageIndicator(
+            YaruPageIndicator.builder(
               length: widget.children.length,
               page: _page,
               onTap: (page) => _controller.animateToPage(page),

--- a/lib/src/widgets/yaru_page_indicator.dart
+++ b/lib/src/widgets/yaru_page_indicator.dart
@@ -25,7 +25,28 @@ typedef YaruPageIndicatorTextBuilder = Widget Function(
 ///  * [YaruCarousel], display a list of widgets in a carousel view.
 class YaruPageIndicator extends StatelessWidget {
   /// Create a [YaruPageIndicator].
-  const YaruPageIndicator({
+  YaruPageIndicator({
+    super.key,
+    required this.length,
+    required this.page,
+    this.onTap,
+    this.itemBuilder,
+    this.mouseCursor,
+    this.textBuilder,
+    this.textStyle,
+    double? dotSize,
+    double? dotSpacing,
+  }) : assert(page >= 0 && page <= length - 1) {
+    itemSizeBuilder =
+        dotSize != null ? (_, __, ___) => Size.square(dotSize) : null;
+    layoutDelegate = dotSpacing != null
+        ? YaruPageIndicatorSteppedDelegate(baseItemSpacing: dotSpacing)
+        : null;
+  }
+
+  /// Create a [YaruPageIndicator].
+  // ignore: prefer_const_constructors_in_immutables
+  YaruPageIndicator.builder({
     super.key,
     required this.length,
     required this.page,
@@ -54,7 +75,7 @@ class YaruPageIndicator extends StatelessWidget {
   /// If you want an animated items size, just return the largest bounds.
   ///
   /// Defaults to a constant 12.0 square.
-  final YaruPageIndicatorItemBuilder<Size>? itemSizeBuilder;
+  late final YaruPageIndicatorItemBuilder<Size>? itemSizeBuilder;
 
   /// Returns the [Widget] of a given item.
   ///
@@ -80,7 +101,7 @@ class YaruPageIndicator extends StatelessWidget {
   /// Controls the items spacing, depending on the vertical constraints.
   ///
   /// Defaults to [YaruPageIndicatorSteppedDelegate].
-  final YaruPageIndicatorLayoutDelegate? layoutDelegate;
+  late final YaruPageIndicatorLayoutDelegate? layoutDelegate;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/widgets/yaru_page_indicator.dart
+++ b/lib/src/widgets/yaru_page_indicator.dart
@@ -46,7 +46,7 @@ class YaruPageIndicator extends StatelessWidget {
 
   /// Create a [YaruPageIndicator].
   // ignore: prefer_const_constructors_in_immutables
-  YaruPageIndicator.builder({
+  YaruPageIndicator.delegate({
     super.key,
     required this.length,
     required this.page,

--- a/lib/src/widgets/yaru_page_indicator.dart
+++ b/lib/src/widgets/yaru_page_indicator.dart
@@ -30,13 +30,13 @@ class YaruPageIndicator extends StatelessWidget {
     required this.length,
     required this.page,
     this.onTap,
-    this.itemBuilder,
     this.mouseCursor,
     this.textBuilder,
     this.textStyle,
     double? dotSize,
     double? dotSpacing,
-  }) : assert(page >= 0 && page <= length - 1) {
+  })  : assert(page >= 0 && page <= length - 1),
+        itemBuilder = null {
     itemSizeBuilder =
         dotSize != null ? (_, __, ___) => Size.square(dotSize) : null;
     layoutDelegate = dotSpacing != null
@@ -46,7 +46,7 @@ class YaruPageIndicator extends StatelessWidget {
 
   /// Create a [YaruPageIndicator].
   // ignore: prefer_const_constructors_in_immutables
-  YaruPageIndicator.delegate({
+  YaruPageIndicator.builder({
     super.key,
     required this.length,
     required this.page,


### PR DESCRIPTION
Restore the old `dotSize` & `dotSpacing` arguments for the default constructor, and introduce an alternative named constructor for the new item size builder and layout delegate. This would be enough to avoid breaking the installer that is already using `dotSize` & `dotSpacing`. WDYT?