### PR TITLE
Add support for high contrast theme

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -33,6 +33,8 @@ class Home extends StatelessWidget {
           debugShowCheckedModeBanner: false,
           theme: yaru.theme,
           darkTheme: yaru.darkTheme,
+          highContrastTheme: yaruHighContrastLight,
+          highContrastDarkTheme: yaruHighContrastDark,
           home: Example.create(context),
         );
       },

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   provider: ^6.0.2
   safe_change_notifier: ^0.2.0
   ubuntu_service: ^0.2.0
-  yaru: ^0.6.0
+  yaru: ^0.6.1
   yaru_icons: ^1.0.0
   yaru_widgets:
     path: ../

--- a/lib/src/widgets/master_detail/yaru_master_tile.dart
+++ b/lib/src/widgets/master_detail/yaru_master_tile.dart
@@ -64,7 +64,10 @@ class YaruMasterTile extends StatelessWidget {
             borderRadius:
                 const BorderRadius.all(Radius.circular(kYaruButtonRadius)),
             side: theme.colorScheme.isHighContrast && isSelected
-                ? BorderSide(color: theme.colorScheme.outlineVariant)
+                ? BorderSide(
+                    color: theme.colorScheme.outlineVariant,
+                    strokeAlign: 1,
+                  )
                 : BorderSide.none,
           ),
           leading: leading,

--- a/lib/src/widgets/master_detail/yaru_master_tile.dart
+++ b/lib/src/widgets/master_detail/yaru_master_tile.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:yaru/yaru.dart';
 import 'package:yaru_widgets/constants.dart';
 
 const double _kScrollbarThickness = 8.0;
@@ -59,8 +60,12 @@ class YaruMasterTile extends StatelessWidget {
           selectedColor: theme.colorScheme.onSurface,
           iconColor: theme.colorScheme.onSurface.withOpacity(0.8),
           visualDensity: const VisualDensity(horizontal: -4, vertical: -4),
-          shape: const RoundedRectangleBorder(
-            borderRadius: BorderRadius.all(Radius.circular(kYaruButtonRadius)),
+          shape: RoundedRectangleBorder(
+            borderRadius:
+                const BorderRadius.all(Radius.circular(kYaruButtonRadius)),
+            side: theme.colorScheme.isHighContrast && isSelected
+                ? BorderSide(color: theme.colorScheme.outlineVariant)
+                : BorderSide.none,
           ),
           leading: leading,
           title: _titleStyle(context, title),

--- a/lib/src/widgets/master_detail/yaru_master_tile.dart
+++ b/lib/src/widgets/master_detail/yaru_master_tile.dart
@@ -66,7 +66,7 @@ class YaruMasterTile extends StatelessWidget {
             side: theme.colorScheme.isHighContrast && isSelected
                 ? BorderSide(
                     color: theme.colorScheme.outlineVariant,
-                    strokeAlign: 1,
+                    strokeAlign: BorderSide.strokeAlignOutside,
                   )
                 : BorderSide.none,
           ),

--- a/lib/src/widgets/yaru_title_bar.dart
+++ b/lib/src/widgets/yaru_title_bar.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:yaru/yaru.dart';
 import 'package:yaru_colors/yaru_colors.dart';
 import 'package:yaru_widgets/constants.dart';
 import 'package:yaru_window/yaru_window.dart';
@@ -131,7 +132,8 @@ class YaruTitleBar extends StatelessWidget implements PreferredSizeWidget {
     if (style == YaruTitleBarStyle.hidden) return const SizedBox.shrink();
 
     final theme = Theme.of(context);
-    final light = theme.brightness == Brightness.light;
+    final light = theme.colorScheme.isLight;
+    final highContrast = theme.colorScheme.isHighContrast;
     final states = <MaterialState>{
       if (isActive != false) MaterialState.focused,
     };
@@ -161,8 +163,8 @@ class YaruTitleBar extends StatelessWidget implements PreferredSizeWidget {
 
     final defaultBorder = BorderSide(
       color: light
-          ? Colors.black.withOpacity(0.1)
-          : Colors.white.withOpacity(0.06),
+          ? Colors.black.withOpacity(highContrast ? 1 : 0.1)
+          : Colors.white.withOpacity(highContrast ? 1 : 0.06),
     );
     final border =
         Border(bottom: this.border ?? titleBarTheme.border ?? defaultBorder);

--- a/lib/src/widgets/yaru_window_control.dart
+++ b/lib/src/widgets/yaru_window_control.dart
@@ -150,7 +150,7 @@ class _YaruWindowControlState extends State<YaruWindowControl>
           decoration: BoxDecoration(
             color: _getColor(context),
             border: colorScheme.isHighContrast
-                ? Border.all(color: colorScheme.outlineVariant)
+                ? Border.all(color: colorScheme.outlineVariant, strokeAlign: 1)
                 : null,
             shape: BoxShape.circle,
           ),

--- a/lib/src/widgets/yaru_window_control.dart
+++ b/lib/src/widgets/yaru_window_control.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:yaru/yaru.dart';
 
 /// The size of [YaruWindowControl].
 const kYaruWindowControlSize = 24.0;
@@ -141,12 +142,16 @@ class _YaruWindowControlState extends State<YaruWindowControl>
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
     return _buildEventDetectors(
       RepaintBoundary(
         child: AnimatedContainer(
           duration: _kWindowControlBackgroundAnimationDuration,
           decoration: BoxDecoration(
             color: _getColor(context),
+            border: colorScheme.isHighContrast
+                ? Border.all(color: colorScheme.outlineVariant)
+                : null,
             shape: BoxShape.circle,
           ),
           child: SizedBox.square(

--- a/lib/src/widgets/yaru_window_control.dart
+++ b/lib/src/widgets/yaru_window_control.dart
@@ -150,7 +150,10 @@ class _YaruWindowControlState extends State<YaruWindowControl>
           decoration: BoxDecoration(
             color: _getColor(context),
             border: colorScheme.isHighContrast
-                ? Border.all(color: colorScheme.outlineVariant, strokeAlign: 1)
+                ? Border.all(
+                    color: colorScheme.outlineVariant,
+                    strokeAlign: BorderSide.strokeAlignOutside,
+                  )
                 : null,
             shape: BoxShape.circle,
           ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  yaru: ^0.6.0
+  yaru: ^0.6.1
   yaru_colors: ^0.1.2
   yaru_icons: ^1.0.0
   yaru_window: ^0.1.1


### PR DESCRIPTION
Adds high contrast borders to
- `YaruTitleBar`
- `YaruWindowControl`
- `YaruMasterTile`

![image](https://user-images.githubusercontent.com/113362648/227244366-3f455ecf-6b69-45f7-9056-e0761eb8cd54.png)
