### PR TITLE
YaruWindowTitleBar.ensureInitialized(): clear cached window states

### DIFF
--- a/lib/src/widgets/yaru_title_bar.dart
+++ b/lib/src/widgets/yaru_title_bar.dart
@@ -481,6 +481,7 @@ class YaruWindowTitleBar extends StatelessWidget
       Size(0, style == YaruTitleBarStyle.hidden ? 0 : kYaruTitleBarHeight);
 
   static Future<void> ensureInitialized() {
+    _windowStates.clear();
     return YaruWindow.ensureInitialized().then((window) => window.hideTitle());
   }
 


### PR DESCRIPTION
This allows removing any previously cached window state during the test setup phase.