### PR TITLE
YaruTitleBarTheme: fix border side lerp

### DIFF
--- a/lib/src/widgets/yaru_title_bar_theme.dart
+++ b/lib/src/widgets/yaru_title_bar_theme.dart
@@ -100,13 +100,31 @@ class YaruTitleBarThemeData extends ThemeExtension<YaruTitleBarThemeData>
       ),
       titleTextStyle: TextStyle.lerp(titleTextStyle, o?.titleTextStyle, t),
       shape: ShapeBorder.lerp(shape, o?.shape, t),
-      border: BorderSide.lerp(
-        border ?? BorderSide.none,
-        o?.border ?? BorderSide.none,
-        t,
-      ),
+      border: _lerpBorderSide(border, o?.border, t),
       style: t < 0.5 ? style : o?.style,
     );
+  }
+
+  // Special case because BorderSide.lerp() doesn't support null arguments.
+  static BorderSide? _lerpBorderSide(BorderSide? a, BorderSide? b, double t) {
+    if (a == null && b == null) {
+      return null;
+    }
+    if (a == null) {
+      return BorderSide.lerp(
+        BorderSide(width: 0, color: b!.color.withAlpha(0)),
+        b,
+        t,
+      );
+    }
+    if (b == null) {
+      return BorderSide.lerp(
+        BorderSide(width: 0, color: a.color.withAlpha(0)),
+        a,
+        t,
+      );
+    }
+    return BorderSide.lerp(a, b, t);
   }
 
   @override


### PR DESCRIPTION
The issue is not super well visible in the compressed recordings but basically, the title bar border disappears for a moment whenever the entire app is rebuilt due to language change, and the AnimatedTheme baked into MaterialApp kicks in.

### Before

[Screencast from 2023-03-30 13-19-49.webm](https://user-images.githubusercontent.com/140617/228820562-b4a557fe-775b-4e70-97c3-b36296702e0b.webm)

### After

[Screencast from 2023-03-30 13-20-36.webm](https://user-images.githubusercontent.com/140617/228820610-be7f60c6-df9d-41e1-bfd5-e8a69b238928.webm)

