### PR TITLE
YaruCheckbox/Radio/Switch: fix high-contrast borders

### DIFF
--- a/lib/src/widgets/yaru_switch.dart
+++ b/lib/src/widgets/yaru_switch.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:yaru/yaru.dart';
 
 import 'yaru_checkbox.dart';
 import 'yaru_radio.dart';
@@ -168,18 +169,22 @@ class _YaruSwitchState extends YaruTogglableState<YaruSwitch> {
       MaterialState.disabled
     };
 
+    final defaultBorderColor = colorScheme.isHighContrast
+        ? colorScheme.outlineVariant
+        : Colors.transparent;
+
     // Normal colors
     final uncheckedColor = switchTheme.color?.resolve(unselectedState) ??
         colorScheme.onSurface.withOpacity(.25);
     final uncheckedBorderColor =
-        switchTheme.borderColor?.resolve(unselectedState) ?? Colors.transparent;
+        switchTheme.borderColor?.resolve(unselectedState) ?? defaultBorderColor;
     final uncheckedThumbColor =
         switchTheme.thumbColor?.resolve(unselectedState) ?? Colors.white;
     final checkedColor = widget.selectedColor ??
         switchTheme.color?.resolve(selectedState) ??
         painter.checkedColor;
     final checkedBorderColor =
-        switchTheme.borderColor?.resolve(selectedState) ?? Colors.transparent;
+        switchTheme.borderColor?.resolve(selectedState) ?? defaultBorderColor;
     final checkedThumbColor = widget.thumbColor ??
         switchTheme.thumbColor?.resolve(selectedState) ??
         painter.checkmarkColor;
@@ -188,7 +193,7 @@ class _YaruSwitchState extends YaruTogglableState<YaruSwitch> {
     final disabledUncheckedColor = switchTheme.color?.resolve(disabledState) ??
         painter.disabledUncheckedColor;
     final disabledUncheckedBorderColor =
-        switchTheme.borderColor?.resolve(disabledState) ?? Colors.transparent;
+        switchTheme.borderColor?.resolve(disabledState) ?? defaultBorderColor;
     final disabledUncheckedThumbColor =
         switchTheme.thumbColor?.resolve(disabledState) ??
             colorScheme.onSurface.withOpacity(.4);
@@ -197,7 +202,7 @@ class _YaruSwitchState extends YaruTogglableState<YaruSwitch> {
             painter.disabledCheckedColor;
     final disabledCheckedBorderColor =
         switchTheme.borderColor?.resolve(selectedDisabledState) ??
-            Colors.transparent;
+            defaultBorderColor;
     final disabledCheckedThumbColor =
         switchTheme.thumbColor?.resolve(selectedDisabledState) ??
             disabledUncheckedThumbColor;

--- a/lib/src/widgets/yaru_togglable.dart
+++ b/lib/src/widgets/yaru_togglable.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:yaru/yaru.dart';
 
 import 'yaru_checkbox.dart';
 import 'yaru_radio.dart';
@@ -275,18 +276,24 @@ abstract class YaruTogglableState<S extends YaruTogglable> extends State<S>
 
     // Normal colors
     final uncheckedColor = colorScheme.surface;
-    final uncheckedBorderColor = theme.brightness == Brightness.light
-        ? const Color(0xFF959595)
-        : const Color(0xFF757575);
+    final uncheckedBorderColor = colorScheme.isHighContrast
+        ? colorScheme.outlineVariant
+        : theme.brightness == Brightness.light
+            ? const Color(0xFF959595)
+            : const Color(0xFF757575);
     final checkedColor = colorScheme.primary;
     const checkedBorderColor = Colors.transparent;
     final checkmarkColor = colorScheme.onPrimary;
 
     // Disabled colors
     final disabledUncheckedColor = colorScheme.onSurface.withOpacity(.1);
-    final disabledUncheckedBorderColor = disabledUncheckedColor;
+    final disabledUncheckedBorderColor = colorScheme.isHighContrast
+        ? colorScheme.outlineVariant
+        : disabledUncheckedColor;
     final disabledCheckedColor = colorScheme.onSurface.withOpacity(.2);
-    const disabledCheckedBorderColor = Colors.transparent;
+    final disabledCheckedBorderColor = colorScheme.isHighContrast
+        ? colorScheme.outlineVariant
+        : Colors.transparent;
     final disabledCheckmarkColor = colorScheme.onSurface.withOpacity(.5);
 
     // Indicator colors


### PR DESCRIPTION
Affects high-contrast themes only (no changes to golden images).

## YaruCheckbox

|       | Before | After |
|-------|--------|-------|
| Light | ![image](https://user-images.githubusercontent.com/140617/234605544-e88eb9e6-1efc-41cd-8e7b-72693d334cd8.png) | ![image](https://user-images.githubusercontent.com/140617/234605391-383c5ab4-492d-4ba2-9a1c-e498969e1074.png) |
| Dark  | ![image](https://user-images.githubusercontent.com/140617/234605808-6f9f2eff-8023-43f9-ab54-9a479acc2305.png) | ![image](https://user-images.githubusercontent.com/140617/234605058-8b257c81-9187-4e15-9758-16a20ac0269c.png) |

## YaruRadio

|       | Before | After |
|-------|--------|-------|
| Light | ![image](https://user-images.githubusercontent.com/140617/234605593-3239bdbe-a7d9-41f1-bbfe-3d6334f74f9e.png) | ![image](https://user-images.githubusercontent.com/140617/234605354-afbe3dd2-fac8-45e9-8f9c-23ee2eb16a3d.png) |
| Dark  | ![image](https://user-images.githubusercontent.com/140617/234605748-8ad26d75-5f62-439b-8879-c807497b8e53.png) | ![image](https://user-images.githubusercontent.com/140617/234605119-d82cdb69-fdd8-4198-a7a3-e28b9aa92ec5.png) |

## YaruSwitch

|       | Before | After |
|-------|--------|-------|
| Light | ![image](https://user-images.githubusercontent.com/140617/234605622-002a8270-8665-4201-a42b-6d2a58f2213c.png) | ![image](https://user-images.githubusercontent.com/140617/234605326-21db863a-c789-4ef1-9794-e9515602e32b.png) |
| Dark  | ![image](https://user-images.githubusercontent.com/140617/234605699-51134480-99a8-47c2-bc42-b03a46b13039.png) | ![image](https://user-images.githubusercontent.com/140617/234605158-385f045a-c727-432e-ada3-d013d0d9a25c.png) |
