### PR TITLE
Upgrade to `flutter_lints` 2.0

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -9,7 +9,6 @@ linter:
     avoid_equals_and_hash_code_on_mutable_classes: true
     avoid_types_on_closure_parameters: true
     cancel_subscriptions: true
-    depend_on_referenced_packages: true
     directives_ordering: true
     eol_at_end_of_file: true
     omit_local_variable_types: true
@@ -25,7 +24,6 @@ linter:
     type_annotate_public_apis: true
     unawaited_futures: true
     unnecessary_lambdas: true
-    unnecessary_late: true
     unnecessary_parenthesis: true
     use_named_constants: true
     use_super_parameters: true

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -9,7 +9,6 @@ linter:
     avoid_equals_and_hash_code_on_mutable_classes: true
     avoid_types_on_closure_parameters: true
     cancel_subscriptions: true
-    depend_on_referenced_packages: true
     directives_ordering: true
     eol_at_end_of_file: true
     omit_local_variable_types: true
@@ -26,6 +25,5 @@ linter:
     type_annotate_public_apis: true
     unawaited_futures: true
     unnecessary_lambdas: true
-    unnecessary_late: true
     unnecessary_parenthesis: true
     use_named_constants: true

--- a/example/lib/code_snippet_button.dart
+++ b/example/lib/code_snippet_button.dart
@@ -33,11 +33,11 @@ class CodeSnippedButton extends StatelessWidget {
           );
         },
       ),
-      child: const Icon(YaruIcons.code),
       tooltip: 'Example snippet',
       foregroundColor: Theme.of(context).colorScheme.onSurface,
       backgroundColor: PopupMenuTheme.of(context).color,
       shape: PopupMenuTheme.of(context).shape,
+      child: const Icon(YaruIcons.code),
     );
   }
 }

--- a/example/lib/pages/carousel_page.dart
+++ b/example/lib/pages/carousel_page.dart
@@ -6,7 +6,7 @@ class CarouselPage extends StatefulWidget {
   const CarouselPage({super.key});
 
   @override
-  _CarouselPageState createState() => _CarouselPageState();
+  State<CarouselPage> createState() => _CarouselPageState();
 }
 
 class _CarouselPageState extends State<CarouselPage> {
@@ -28,9 +28,9 @@ class _CarouselPageState extends State<CarouselPage> {
           headline: const Text('Auto scroll: off'),
           width: 700,
           child: YaruCarousel(
-            children: _getCarouselChildren(),
             height: 400,
             navigationControls: true,
+            children: _getCarouselChildren(),
           ),
         ),
         const SizedBox(height: 20),
@@ -39,8 +39,8 @@ class _CarouselPageState extends State<CarouselPage> {
           width: 700,
           child: YaruCarousel(
             controller: _autoScrollController,
-            children: _getCarouselChildren(),
             height: 400,
+            children: _getCarouselChildren(),
           ),
         ),
         ButtonBar(

--- a/example/lib/pages/checkbox_page.dart
+++ b/example/lib/pages/checkbox_page.dart
@@ -5,7 +5,7 @@ class CheckboxPage extends StatefulWidget {
   const CheckboxPage({super.key});
 
   @override
-  _CheckboxPageState createState() => _CheckboxPageState();
+  State<CheckboxPage> createState() => _CheckboxPageState();
 }
 
 class _CheckboxPageState extends State<CheckboxPage> {

--- a/example/lib/pages/expandable_page.dart
+++ b/example/lib/pages/expandable_page.dart
@@ -13,11 +13,11 @@ class ExpandablePage extends StatelessWidget {
       padding: const EdgeInsets.all(kYaruPagePadding),
       children: const [
         YaruExpandable(
-          child: Text(_lorem),
           header: Text(
             'Lorem ipsum dolor sit amet',
             style: TextStyle(fontWeight: FontWeight.bold),
           ),
+          child: Text(_lorem),
         ),
         YaruExpandable(
           isExpanded: true,
@@ -26,11 +26,11 @@ class ExpandablePage extends StatelessWidget {
             maxLines: 5,
             overflow: TextOverflow.fade,
           ),
-          child: Text(_lorem),
           header: Text(
             'Lorem ipsum dolor sit amet',
             style: TextStyle(fontWeight: FontWeight.bold),
           ),
+          child: Text(_lorem),
         )
       ],
     );

--- a/example/lib/pages/icon_button_page.dart
+++ b/example/lib/pages/icon_button_page.dart
@@ -6,7 +6,7 @@ class IconButtonPage extends StatefulWidget {
   const IconButtonPage({super.key});
 
   @override
-  _IconButtonPageState createState() => _IconButtonPageState();
+  State<IconButtonPage> createState() => _IconButtonPageState();
 }
 
 class _IconButtonPageState extends State<IconButtonPage> {

--- a/example/lib/pages/option_button_page.dart
+++ b/example/lib/pages/option_button_page.dart
@@ -6,7 +6,7 @@ class OptionButtonPage extends StatefulWidget {
   const OptionButtonPage({super.key});
 
   @override
-  _OptionButtonPageState createState() => _OptionButtonPageState();
+  State<OptionButtonPage> createState() => _OptionButtonPageState();
 }
 
 class _OptionButtonPageState extends State<OptionButtonPage> {

--- a/example/lib/pages/popup_page.dart
+++ b/example/lib/pages/popup_page.dart
@@ -67,7 +67,6 @@ class _PopupPageState extends State<PopupPage> {
                 for (final value in MyEnum.values)
                   YaruMultiSelectPopupMenuItem<MyEnum>(
                     value: value,
-                    child: Text(value.name),
                     checked: enumSet.contains(value),
                     onChanged: (checked) {
                       // Handle model changes here
@@ -75,6 +74,7 @@ class _PopupPageState extends State<PopupPage> {
                         checked ? enumSet.add(value) : enumSet.remove(value);
                       });
                     },
+                    child: Text(value.name),
                   )
               ];
             },

--- a/example/lib/pages/radio_page.dart
+++ b/example/lib/pages/radio_page.dart
@@ -5,7 +5,7 @@ class RadioPage extends StatefulWidget {
   const RadioPage({super.key});
 
   @override
-  _RadioPageState createState() => _RadioPageState();
+  State<RadioPage> createState() => _RadioPageState();
 }
 
 class _RadioPageState extends State<RadioPage> {

--- a/example/lib/pages/section_page.dart
+++ b/example/lib/pages/section_page.dart
@@ -8,7 +8,7 @@ class SectionPage extends StatefulWidget {
   const SectionPage({super.key});
 
   @override
-  _SectionPageState createState() => _SectionPageState();
+  State<SectionPage> createState() => _SectionPageState();
 }
 
 class _SectionPageState extends State<SectionPage> {
@@ -50,19 +50,19 @@ class DummySection extends StatelessWidget {
         children: const [
           Text('Headline'),
           SizedBox(
-            child: YaruCircularProgressIndicator(strokeWidth: 3),
             height: 20,
             width: 20,
+            child: YaruCircularProgressIndicator(strokeWidth: 3),
           )
         ],
       ),
+      width: width,
       child: const YaruTile(
         title: Text('Title'),
         trailing: Icon(YaruIcons.information),
         leading: Icon(YaruIcons.music_note),
         subtitle: Text('Subtitle'),
       ),
-      width: width,
     );
   }
 }

--- a/example/lib/pages/switch_page.dart
+++ b/example/lib/pages/switch_page.dart
@@ -5,7 +5,7 @@ class SwitchPage extends StatefulWidget {
   const SwitchPage({super.key});
 
   @override
-  _SwitchPageState createState() => _SwitchPageState();
+  State<SwitchPage> createState() => _SwitchPageState();
 }
 
 class _SwitchPageState extends State<SwitchPage> {

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
     path: ../
 
 dev_dependencies:
-  flutter_lints: ^1.0.0
+  flutter_lints: ^2.0.1
   flutter_test:
     sdk: flutter
 

--- a/lib/src/widgets/master_detail/yaru_landscape_layout.dart
+++ b/lib/src/widgets/master_detail/yaru_landscape_layout.dart
@@ -211,6 +211,11 @@ class _YaruLandscapeLayoutState extends State<YaruLandscapeLayout> {
     final isRtl = Directionality.of(context) == TextDirection.rtl;
 
     return Positioned(
+      width: _kLeftPaneResizingRegionWidth,
+      top: 0,
+      bottom: 0,
+      left: isRtl ? null : 0,
+      right: isRtl ? 0 : null,
       child: AnimatedContainer(
         duration: _kLeftPaneResizingRegionAnimationDuration,
         color: _isHovering || _isDragging
@@ -243,11 +248,6 @@ class _YaruLandscapeLayoutState extends State<YaruLandscapeLayout> {
           ),
         ),
       ),
-      width: _kLeftPaneResizingRegionWidth,
-      top: 0,
-      bottom: 0,
-      left: isRtl ? null : 0,
-      right: isRtl ? 0 : null,
     );
   }
 }

--- a/lib/src/widgets/master_detail/yaru_master_detail_page.dart
+++ b/lib/src/widgets/master_detail/yaru_master_detail_page.dart
@@ -130,7 +130,7 @@ class YaruMasterDetailPage extends StatefulWidget {
   }
 
   @override
-  _YaruMasterDetailPageState createState() => _YaruMasterDetailPageState();
+  State<YaruMasterDetailPage> createState() => _YaruMasterDetailPageState();
 }
 
 class _YaruMasterDetailPageState extends State<YaruMasterDetailPage> {

--- a/lib/src/widgets/master_detail/yaru_portrait_layout.dart
+++ b/lib/src/widgets/master_detail/yaru_portrait_layout.dart
@@ -29,7 +29,7 @@ class YaruPortraitLayout extends StatefulWidget {
   final YaruPageController controller;
 
   @override
-  _YaruPortraitLayoutState createState() => _YaruPortraitLayoutState();
+  State<YaruPortraitLayout> createState() => _YaruPortraitLayoutState();
 }
 
 class _YaruPortraitLayoutState extends State<YaruPortraitLayout> {

--- a/lib/src/widgets/yaru_circular_progress_indicator.dart
+++ b/lib/src/widgets/yaru_circular_progress_indicator.dart
@@ -1,4 +1,5 @@
 import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 
 import 'yaru_progress_indicator.dart';
@@ -24,7 +25,7 @@ class YaruCircularProgressIndicator extends YaruProgressIndicator {
   final double strokeWidth;
 
   @override
-  _YaruCircularProgressIndicatorState createState() =>
+  State<YaruCircularProgressIndicator> createState() =>
       _YaruCircularProgressIndicatorState();
 }
 

--- a/lib/src/widgets/yaru_draggable.dart
+++ b/lib/src/widgets/yaru_draggable.dart
@@ -21,7 +21,7 @@ class YaruDraggable extends StatefulWidget {
     BuildContext context,
     Offset position,
     bool isDragging,
-    bool _isHovering,
+    bool isHovering,
   ) childBuilder;
 
   /// Callback called when this element starts to be dragged
@@ -46,7 +46,7 @@ class YaruDraggable extends StatefulWidget {
   final MouseCursor? dragCursor;
 
   @override
-  _YaruDraggableState createState() => _YaruDraggableState();
+  State<YaruDraggable> createState() => _YaruDraggableState();
 }
 
 class _YaruDraggableState extends State<YaruDraggable> {

--- a/lib/src/widgets/yaru_expansion_panel_list.dart
+++ b/lib/src/widgets/yaru_expansion_panel_list.dart
@@ -83,16 +83,16 @@ class YaruExpansionPanelList extends StatelessWidget {
         ],
       );
 
-      const _radiusValue = kYaruContainerRadius;
+      const radiusValue = kYaruContainerRadius;
       final borderRadius = index == 0
           ? const BorderRadius.only(
-              topLeft: Radius.circular(_radiusValue),
-              topRight: Radius.circular(_radiusValue),
+              topLeft: Radius.circular(radiusValue),
+              topRight: Radius.circular(radiusValue),
             )
           : index == children.length - 1
               ? const BorderRadius.only(
-                  bottomLeft: Radius.circular(_radiusValue),
-                  bottomRight: Radius.circular(_radiusValue),
+                  bottomLeft: Radius.circular(radiusValue),
+                  bottomRight: Radius.circular(radiusValue),
                 )
               : BorderRadius.zero;
       items.add(

--- a/lib/src/widgets/yaru_linear_progress_indicator.dart
+++ b/lib/src/widgets/yaru_linear_progress_indicator.dart
@@ -22,7 +22,7 @@ class YaruLinearProgressIndicator extends YaruProgressIndicator {
   final double minHeight;
 
   @override
-  _YaruLinearProgressIndicatorState createState() =>
+  State<YaruLinearProgressIndicator> createState() =>
       _YaruLinearProgressIndicatorState();
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
 
 dev_dependencies:
   collection: ^1.16.0
-  flutter_lints: ^1.0.0
+  flutter_lints: ^2.0.1
   flutter_test:
     sdk: flutter
   golden_toolkit: ^0.13.0

--- a/test/widgets/yaru_popup_menu_button_test.dart
+++ b/test/widgets/yaru_popup_menu_button_test.dart
@@ -12,9 +12,9 @@ void main() {
 
       await tester.pumpScaffold(
         YaruPopupMenuButton<dynamic>(
-          child: const Text('Menu'),
           itemBuilder: (context) => [],
           enabled: !variant.hasState(MaterialState.disabled),
+          child: const Text('Menu'),
         ),
         themeMode: variant.themeMode,
         size: const Size(104, 48),

--- a/test/widgets/yaru_popup_menu_item_test.dart
+++ b/test/widgets/yaru_popup_menu_item_test.dart
@@ -16,9 +16,9 @@ void main() {
           itemBuilder: (context) => [
             for (var i = 0; i < 3; ++i)
               YaruCheckedPopupMenuItem(
-                child: Text('YaruPopupMenuItem $i'),
                 checked: variant.hasState(MaterialState.selected),
                 enabled: !variant.hasState(MaterialState.disabled),
+                child: Text('YaruPopupMenuItem $i'),
               ),
           ],
         ),

--- a/test/yaru_golden_tester.dart
+++ b/test/yaru_golden_tester.dart
@@ -23,8 +23,8 @@ extension YaruGoldenTester on WidgetTester {
         debugShowCheckedModeBanner: false,
         home: Scaffold(
           body: Align(
-            child: widget,
             alignment: alignment,
+            child: widget,
           ),
         ),
       ),


### PR DESCRIPTION
<!-- REMINDER:

1) For a bug fix, please target the `release` branch, else target `main`.

2) If this PR introduces any visual changes, please run:
```
flutter test --update-goldens
```
and commit the changes **or** if not covered by tests, attach screenshots below:

|       | Before | After |
|-------|--------|-------|
| Light |        |       |
| Dark  |        |       |

-->

This PR upgrades the dependency of [`flutter_lints`](https://pub.dev/packages/flutter_lints) to its current major version.

The only breaking change was that it increased Dart SDK's constraints to `>=2.17.0`, but this package already has that requirement since 7e3bde7.

I've also removed two rules that were manually enabled, since the new version of [`lints`](https://pub.dev/packages/lints) (which `flutter_lints` depends on) already enables them. New linter warnings appear after upgrading, and I've fixed some of those with `dart fix --apply` and others manually.

I did the same for the `example` project.
