### PR TITLE
Remove useless YaruMasterListView.materialTiles

### DIFF
--- a/lib/src/widgets/master_detail/yaru_master_list_view.dart
+++ b/lib/src/widgets/master_detail/yaru_master_list_view.dart
@@ -11,14 +11,12 @@ class YaruMasterListView extends StatefulWidget {
     required this.selectedIndex,
     required this.builder,
     required this.onTap,
-    this.materialTiles = false,
   });
 
   final int length;
   final YaruMasterDetailBuilder builder;
   final int selectedIndex;
   final ValueChanged<int> onTap;
-  final bool materialTiles;
 
   @override
   State<YaruMasterListView> createState() => _YaruMasterListViewState();


### PR DESCRIPTION
Remove useless `YaruMasterListView.materialTiles` which is no longer used anywhere.

Closes #706 