### PR TITLE
Pass available width to YaruMasterDetailBuilder

### DIFF
--- a/example/lib/example.dart
+++ b/example/lib/example.dart
@@ -61,7 +61,7 @@ class _MasterDetailPage extends StatelessWidget {
         minPaneWidth: 175,
       ),
       length: pageItems.length,
-      tileBuilder: (context, index, selected) => YaruMasterTile(
+      tileBuilder: (context, index, selected, availableWidth) => YaruMasterTile(
         leading: pageItems[index].iconBuilder(context, selected),
         title: buildTitle(context, pageItems[index]),
       ),

--- a/lib/src/widgets/master_detail/yaru_landscape_layout.dart
+++ b/lib/src/widgets/master_detail/yaru_landscape_layout.dart
@@ -165,6 +165,7 @@ class _YaruLandscapeLayoutState extends State<YaruLandscapeLayout> {
             selectedIndex: _selectedIndex,
             onTap: _onTap,
             builder: widget.tileBuilder,
+            availableWidth: _paneWidth!,
           ),
           bottomNavigationBar: widget.bottomBar,
         ),

--- a/lib/src/widgets/master_detail/yaru_master_detail_page.dart
+++ b/lib/src/widgets/master_detail/yaru_master_detail_page.dart
@@ -14,6 +14,7 @@ typedef YaruMasterDetailBuilder = Widget Function(
   BuildContext context,
   int index,
   bool selected,
+  double availableWidth,
 );
 
 typedef YaruAppBarBuilder = PreferredSizeWidget? Function(BuildContext context);

--- a/lib/src/widgets/master_detail/yaru_master_list_view.dart
+++ b/lib/src/widgets/master_detail/yaru_master_list_view.dart
@@ -11,14 +11,14 @@ class YaruMasterListView extends StatefulWidget {
     required this.selectedIndex,
     required this.builder,
     required this.onTap,
-    this.materialTiles = false,
+    required this.availableWidth,
   });
 
   final int length;
   final YaruMasterDetailBuilder builder;
   final int selectedIndex;
   final ValueChanged<int> onTap;
-  final bool materialTiles;
+  final double availableWidth;
 
   @override
   State<YaruMasterListView> createState() => _YaruMasterListViewState();
@@ -46,8 +46,12 @@ class _YaruMasterListViewState extends State<YaruMasterListView> {
         selected: index == widget.selectedIndex,
         onTap: () => widget.onTap(index),
         child: Builder(
-          builder: (context) =>
-              widget.builder(context, index, index == widget.selectedIndex),
+          builder: (context) => widget.builder(
+            context,
+            index,
+            index == widget.selectedIndex,
+            widget.availableWidth,
+          ),
         ),
       ),
     );

--- a/lib/src/widgets/master_detail/yaru_portrait_layout.dart
+++ b/lib/src/widgets/master_detail/yaru_portrait_layout.dart
@@ -105,11 +105,14 @@ class _YaruPortraitLayoutState extends State<YaruPortraitLayout> {
                 ),
                 child: Scaffold(
                   appBar: widget.appBar,
-                  body: YaruMasterListView(
-                    length: widget.controller.length,
-                    selectedIndex: _selectedIndex,
-                    onTap: _onTap,
-                    builder: widget.tileBuilder,
+                  body: LayoutBuilder(
+                    builder: (context, constraints) => YaruMasterListView(
+                      length: widget.controller.length,
+                      selectedIndex: _selectedIndex,
+                      onTap: _onTap,
+                      builder: widget.tileBuilder,
+                      availableWidth: constraints.maxWidth,
+                    ),
                   ),
                   bottomNavigationBar: widget.bottomBar,
                 ),

--- a/test/widgets/yaru_master_detail_page_test.dart
+++ b/test/widgets/yaru_master_detail_page_test.dart
@@ -18,7 +18,7 @@ void main() {
           ),
           length: 8,
           appBar: AppBar(title: const Text('Master')),
-          tileBuilder: (context, index, selected) => YaruMasterTile(
+          tileBuilder: (context, index, selected, maxWidth) => YaruMasterTile(
             leading: const Icon(YaruIcons.menu),
             title: Text('Tile $index'),
           ),
@@ -65,7 +65,7 @@ void main() {
               paneWidth: kYaruMasterDetailBreakpoint / 3,
             ),
             appBar: AppBar(title: const Text('Master')),
-            tileBuilder: (context, index, selected) => YaruMasterTile(
+            tileBuilder: (context, index, selected, maxWidth) => YaruMasterTile(
               leading: const Icon(YaruIcons.menu),
               title: Text('Tile $index'),
             ),


### PR DESCRIPTION
Pass available pane width to `YaruMasterDetailBuilder`.

This allows the tile builder to be responsive without needing a `LayoutBuilder` for each tile.