### PR TITLE
Add YaruChoiceChipBar

### DIFF
--- a/example/lib/example_page_items.dart
+++ b/example/lib/example_page_items.dart
@@ -7,6 +7,7 @@ import 'pages/autocomplete_page.dart';
 import 'pages/banner_page.dart';
 import 'pages/carousel_page.dart';
 import 'pages/checkbox_page.dart';
+import 'pages/choice_chip_bar_page.dart';
 import 'pages/clip_page.dart';
 import 'pages/color_disk_page.dart';
 import 'pages/dialog_page.dart';
@@ -76,6 +77,13 @@ final examplePageItems = <PageItem>[
     iconBuilder: (context, selected) => selected
         ? const Icon(YaruIcons.checkbox_checked_filled)
         : const Icon(YaruIcons.checkbox_checked),
+  ),
+  PageItem(
+    title: 'YaruChoiceChipBar',
+    snippetUrl:
+        'https://raw.githubusercontent.com/ubuntu/yaru_widgets.dart/main/example/lib/pages/filter_pills_page.dart',
+    iconBuilder: (context, selected) => const Icon(YaruIcons.paper_clip),
+    pageBuilder: (_) => const ChoiceChipBarPage(),
   ),
   PageItem(
     title: 'YaruClip',

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:yaru/yaru.dart';
@@ -36,6 +37,14 @@ class Home extends StatelessWidget {
           highContrastTheme: yaruHighContrastLight,
           highContrastDarkTheme: yaruHighContrastDark,
           home: Example.create(context),
+          scrollBehavior: const MaterialScrollBehavior().copyWith(
+            dragDevices: {
+              PointerDeviceKind.mouse,
+              PointerDeviceKind.touch,
+              PointerDeviceKind.stylus,
+              PointerDeviceKind.unknown
+            },
+          ),
         );
       },
     );

--- a/example/lib/pages/choice_chip_bar_page.dart
+++ b/example/lib/pages/choice_chip_bar_page.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
+
+class ChoiceChipBarPage extends StatefulWidget {
+  const ChoiceChipBarPage({super.key});
+
+  @override
+  State<ChoiceChipBarPage> createState() => _ChoiceChipBarPageState();
+}
+
+class _ChoiceChipBarPageState extends State<ChoiceChipBarPage> {
+  final _labels = [
+    for (var i = 0; i < 15; i++) 'Choice $i',
+  ];
+
+  late List<bool> _isSelected;
+
+  @override
+  void initState() {
+    super.initState();
+    _isSelected = List.generate(_labels.length, (index) => false);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: Column(
+          children: [
+            YaruChoiceChipBar(
+              wrap: false,
+              labels: _labels.map(Text.new).toList(),
+              isSelected: _isSelected,
+              onSelected: (index) => setState(() {
+                _isSelected[index] = !_isSelected[index];
+              }),
+            ),
+            Expanded(
+              child: ListView(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 50, vertical: 20),
+                children: [
+                  for (int i = 0; i < _labels.length; i++)
+                    if (_isSelected[i])
+                      Text(
+                        _labels[i],
+                        style: const TextStyle(
+                          fontSize: 30,
+                        ),
+                      )
+                ],
+              ),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/widgets/yaru_choice_chip_bar.dart
+++ b/lib/src/widgets/yaru_choice_chip_bar.dart
@@ -40,6 +40,12 @@ class _YaruChoiceChipBarState extends State<YaruChoiceChipBar> {
   }
 
   @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     assert(widget.labels.length == widget.isSelected.length);
 

--- a/lib/src/widgets/yaru_choice_chip_bar.dart
+++ b/lib/src/widgets/yaru_choice_chip_bar.dart
@@ -1,0 +1,118 @@
+import 'package:flutter/material.dart';
+import 'package:yaru_icons/yaru_icons.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
+
+class YaruChoiceChipBar extends StatefulWidget {
+  const YaruChoiceChipBar({
+    super.key,
+    this.wrapScrollDirection = Axis.horizontal,
+    required this.labels,
+    required this.onSelected,
+    required this.isSelected,
+    this.wrap = false,
+    this.spacing = 10.0,
+    this.duration = const Duration(milliseconds: 200),
+    this.animationStep = 100.0,
+  });
+  final Axis wrapScrollDirection;
+  final bool wrap;
+  final double spacing;
+  final Duration duration;
+  final double animationStep;
+
+  final List<Widget> labels;
+  final List<bool> isSelected;
+
+  final void Function(int index) onSelected;
+
+  @override
+  State<YaruChoiceChipBar> createState() => _YaruChoiceChipBarState();
+}
+
+class _YaruChoiceChipBarState extends State<YaruChoiceChipBar> {
+  late ScrollController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _controller = ScrollController();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    assert(widget.labels.length == widget.isSelected.length);
+
+    final children = [
+      for (int index = 0; index < widget.labels.length; index++)
+        if (widget.isSelected[index])
+          ChoiceChip(
+            label: widget.labels[index],
+            selected: widget.isSelected[index],
+            onSelected: (v) => widget.onSelected(index),
+          ),
+      for (int index = 0; index < widget.labels.length; index++)
+        if (!widget.isSelected[index])
+          ChoiceChip(
+            label: widget.labels[index],
+            selected: widget.isSelected[index],
+            onSelected: (v) => widget.onSelected(index),
+          )
+    ];
+
+    if (widget.wrap) {
+      return Wrap(
+        spacing: widget.spacing,
+        runSpacing: widget.spacing,
+        direction: widget.wrapScrollDirection,
+        children: children,
+      );
+    } else {
+      return SizedBox(
+        height: 60,
+        child: Row(
+          children: [
+            YaruIconButton(
+              icon: const Icon(YaruIcons.go_previous),
+              onPressed: () => _controller.animateTo(
+                _controller.position.pixels - widget.animationStep,
+                duration: widget.duration,
+                curve: Curves.bounceIn,
+              ),
+            ),
+            SizedBox(
+              width: widget.spacing,
+            ),
+            Expanded(
+              child: ListView(
+                scrollDirection: Axis.horizontal,
+                controller: _controller,
+                children: children
+                    .map(
+                      (e) => Padding(
+                        padding: EdgeInsets.only(
+                          right: widget.spacing,
+                        ),
+                        child: e,
+                      ),
+                    )
+                    .toList(),
+              ),
+            ),
+            SizedBox(
+              width: widget.spacing,
+            ),
+            YaruIconButton(
+              icon: const Icon(YaruIcons.go_next),
+              onPressed: () => _controller.animateTo(
+                _controller.position.pixels + widget.animationStep,
+                duration: widget.duration,
+                curve: Curves.bounceIn,
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+  }
+}

--- a/lib/src/widgets/yaru_choice_chip_bar.dart
+++ b/lib/src/widgets/yaru_choice_chip_bar.dart
@@ -13,7 +13,8 @@ class YaruChoiceChipBar extends StatefulWidget {
     this.spacing = 10.0,
     this.duration = const Duration(milliseconds: 200),
     this.animationStep = 100.0,
-  });
+  }) : assert(labels.length == isSelected.length);
+
   final Axis wrapScrollDirection;
   final bool wrap;
   final double spacing;
@@ -47,8 +48,6 @@ class _YaruChoiceChipBarState extends State<YaruChoiceChipBar> {
 
   @override
   Widget build(BuildContext context) {
-    assert(widget.labels.length == widget.isSelected.length);
-
     final children = [
       for (int index = 0; index < widget.labels.length; index++)
         if (widget.isSelected[index])

--- a/lib/src/widgets/yaru_choice_chip_bar.dart
+++ b/lib/src/widgets/yaru_choice_chip_bar.dart
@@ -32,12 +32,33 @@ class YaruChoiceChipBar extends StatefulWidget {
 
 class _YaruChoiceChipBarState extends State<YaruChoiceChipBar> {
   late ScrollController _controller;
+  bool _enableBackButton = false;
+  bool _enableForwardButton = true;
 
   @override
   void initState() {
     super.initState();
 
-    _controller = ScrollController();
+    _controller = ScrollController()
+      ..addListener(() {
+        if (_controller.position.atEdge) {
+          final isLeft = _controller.position.pixels == 0;
+          setState(() {
+            if (isLeft) {
+              _enableForwardButton = true;
+              _enableBackButton = false;
+            } else {
+              _enableForwardButton = false;
+              _enableBackButton = true;
+            }
+          });
+        } else {
+          setState(() {
+            _enableBackButton = true;
+            _enableForwardButton = true;
+          });
+        }
+      });
   }
 
   @override
@@ -79,11 +100,13 @@ class _YaruChoiceChipBarState extends State<YaruChoiceChipBar> {
           children: [
             YaruIconButton(
               icon: const Icon(YaruIcons.go_previous),
-              onPressed: () => _controller.animateTo(
-                _controller.position.pixels - widget.animationStep,
-                duration: widget.duration,
-                curve: Curves.bounceIn,
-              ),
+              onPressed: _enableBackButton
+                  ? () => _controller.animateTo(
+                        _controller.position.pixels - widget.animationStep,
+                        duration: widget.duration,
+                        curve: Curves.bounceIn,
+                      )
+                  : null,
             ),
             SizedBox(
               width: widget.spacing,
@@ -109,11 +132,13 @@ class _YaruChoiceChipBarState extends State<YaruChoiceChipBar> {
             ),
             YaruIconButton(
               icon: const Icon(YaruIcons.go_next),
-              onPressed: () => _controller.animateTo(
-                _controller.position.pixels + widget.animationStep,
-                duration: widget.duration,
-                curve: Curves.bounceIn,
-              ),
+              onPressed: _enableForwardButton
+                  ? () => _controller.animateTo(
+                        _controller.position.pixels + widget.animationStep,
+                        duration: widget.duration,
+                        curve: Curves.bounceIn,
+                      )
+                  : null,
             ),
           ],
         ),

--- a/lib/widgets.dart
+++ b/lib/widgets.dart
@@ -17,6 +17,7 @@ export 'src/widgets/yaru_check_button.dart';
 export 'src/widgets/yaru_checkbox.dart';
 export 'src/widgets/yaru_checkbox_list_tile.dart';
 export 'src/widgets/yaru_checkbox_theme.dart';
+export 'src/widgets/yaru_choice_chip_bar.dart';
 export 'src/widgets/yaru_circular_progress_indicator.dart';
 export 'src/widgets/yaru_close_button.dart';
 export 'src/widgets/yaru_color_disk.dart';


### PR DESCRIPTION
<!-- REMINDER:

1) For a bug fix, please target the `release` branch, else target `main`.

2) If this PR introduces any visual changes, please run:
```
flutter test --update-goldens
```
and commit the changes **or** if not covered by tests, attach screenshots below:

|       | Before | After |
|-------|--------|-------|
| Light |        |       |
| Dark  |        |       |

-->

I thought this is a useful wrapping around choicechips. I can use it inside MusicPod for filtering different things :)

[Bildschirmaufzeichnung vom 2023-06-19, 21-52-35.webm](https://github.com/ubuntu/yaru_widgets.dart/assets/15329494/3efac21e-2b05-4ba0-b44a-f59fac40d202)
