### PR TITLE
chore(dependabot): configure semantic commits

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,3 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    commit-message:
+      prefix: "chore"
+      include: "scope"


### PR DESCRIPTION
I don't know how exactly dependabot decides between semantic vs. non-semantic commits but the first PR it opened didn't use semantic commits so try explicitly configuring it:

- #726