### PR TITLE
feat: expose YaruNavigationPage.navigatorKey and onGenerateRoute

### DIFF
--- a/lib/src/widgets/navi_rail/yaru_navigation_page.dart
+++ b/lib/src/widgets/navi_rail/yaru_navigation_page.dart
@@ -28,6 +28,7 @@ class YaruNavigationPage extends StatefulWidget {
     this.leading,
     this.trailing,
     this.onGenerateRoute,
+    this.navigatorKey,
   })  : assert(initialIndex == null || controller == null),
         assert((length == null) != (controller == null));
 
@@ -64,6 +65,9 @@ class YaruNavigationPage extends StatefulWidget {
   /// Called to generate a route for a given [RouteSettings].
   final RouteFactory? onGenerateRoute;
 
+  /// A key to use when building the [Navigator] widget.
+  final GlobalKey<NavigatorState>? navigatorKey;
+
   @override
   State<YaruNavigationPage> createState() => _YaruNavigationPageState();
 }
@@ -71,12 +75,13 @@ class YaruNavigationPage extends StatefulWidget {
 class _YaruNavigationPageState extends State<YaruNavigationPage> {
   late final ScrollController _scrollController;
   late YaruPageController _pageController;
-  final _navigatorKey = GlobalKey<NavigatorState>();
+  late final GlobalKey<NavigatorState> _navigatorKey;
 
   @override
   void initState() {
     super.initState();
     _scrollController = ScrollController();
+    _navigatorKey = widget.navigatorKey ?? GlobalKey<NavigatorState>();
     _updatePageController();
   }
 

--- a/lib/src/widgets/navi_rail/yaru_navigation_page.dart
+++ b/lib/src/widgets/navi_rail/yaru_navigation_page.dart
@@ -27,6 +27,7 @@ class YaruNavigationPage extends StatefulWidget {
     this.controller,
     this.leading,
     this.trailing,
+    this.onGenerateRoute,
   })  : assert(initialIndex == null || controller == null),
         assert((length == null) != (controller == null));
 
@@ -59,6 +60,9 @@ class YaruNavigationPage extends StatefulWidget {
 
   /// The trailing widget in the rail that is placed below the destinations.
   final Widget? trailing;
+
+  /// Called to generate a route for a given [RouteSettings].
+  final RouteFactory? onGenerateRoute;
 
   @override
   State<YaruNavigationPage> createState() => _YaruNavigationPageState();
@@ -182,6 +186,7 @@ class _YaruNavigationPageState extends State<YaruNavigationPage> {
                   : widget.pageBuilder(context, 0),
             ),
           ],
+          onGenerateRoute: widget.onGenerateRoute,
           onPopPage: (route, result) => route.didPop(result),
           observers: [HeroController()],
         ),


### PR DESCRIPTION
Allows pushing (named) routes onto YaruNavigationPage's internal Navigator. For example:

```dart
YaruNavigationPage(
  navigatorKey: _navigatorKey,
  ...
  onGenerateRoute: (settings) => switch (settings.name) {
    '/detail' => MaterialPageRoute(
        settings: settings,
        builder: (_) => DetailPage(settings.arguments as Detail),
      ),
    '/search' => MaterialPageRoute(
        settings: settings,
        builder: (_) => SearchPage(query: settings.arguments as String),
      ),
    _ => null,
  },
)
```

From within the navigation page:
```dart
Navigator.pushNamed(context, '/detail', arguments: detail);
```

From anywhere else such as a global search bar:
```dart
_navigatorKey.currentState!.pushNamed('/search', arguments: query);
```