### PR TITLE
feat(master-detail): expose Navigator properties

### DIFF
--- a/lib/src/widgets/master_detail/yaru_landscape_layout.dart
+++ b/lib/src/widgets/master_detail/yaru_landscape_layout.dart
@@ -14,6 +14,10 @@ class YaruLandscapeLayout extends StatefulWidget {
   const YaruLandscapeLayout({
     super.key,
     required this.navigatorKey,
+    this.navigatorObservers = const <NavigatorObserver>[],
+    this.initialRoute,
+    this.onGenerateRoute,
+    this.onUnknownRoute,
     required this.tileBuilder,
     required this.pageBuilder,
     this.onSelected,
@@ -26,6 +30,10 @@ class YaruLandscapeLayout extends StatefulWidget {
   });
 
   final GlobalKey<NavigatorState> navigatorKey;
+  final List<NavigatorObserver> navigatorObservers;
+  final String? initialRoute;
+  final RouteFactory? onGenerateRoute;
+  final RouteFactory? onUnknownRoute;
   final YaruMasterTileBuilder tileBuilder;
   final IndexedWidgetBuilder pageBuilder;
   final ValueChanged<int>? onSelected;
@@ -191,6 +199,9 @@ class _YaruLandscapeLayoutState extends State<YaruLandscapeLayout> {
       child: ScaffoldMessenger(
         child: Navigator(
           key: widget.navigatorKey,
+          initialRoute: widget.initialRoute,
+          onGenerateRoute: widget.onGenerateRoute,
+          onUnknownRoute: widget.onUnknownRoute,
           pages: [
             MaterialPage(
               key: ValueKey(_selectedIndex),
@@ -202,7 +213,7 @@ class _YaruLandscapeLayoutState extends State<YaruLandscapeLayout> {
             ),
           ],
           onPopPage: (route, result) => route.didPop(result),
-          observers: [HeroController()],
+          observers: [...widget.navigatorObservers, HeroController()],
         ),
       ),
     );

--- a/lib/src/widgets/master_detail/yaru_master_detail_page.dart
+++ b/lib/src/widgets/master_detail/yaru_master_detail_page.dart
@@ -64,6 +64,11 @@ class YaruMasterDetailPage extends StatefulWidget {
     this.initialIndex,
     this.onSelected,
     this.controller,
+    this.navigatorKey,
+    this.navigatorObservers = const <NavigatorObserver>[],
+    this.initialRoute,
+    this.onGenerateRoute,
+    this.onUnknownRoute,
   })  : assert(initialIndex == null || controller == null),
         assert((length == null) != (controller == null));
 
@@ -115,6 +120,33 @@ class YaruMasterDetailPage extends StatefulWidget {
   /// An optional controller that can be used to navigate to a specific index.
   final YaruPageController? controller;
 
+  /// A key to use when building the [Navigator] widget.
+  final GlobalKey<NavigatorState>? navigatorKey;
+
+  /// A list of observers for the [Navigator] widget.
+  ///
+  /// See also:
+  ///  * [Navigator.observers]
+  final List<NavigatorObserver> navigatorObservers;
+
+  /// The route name for the initial route.
+  ///
+  /// See also:
+  ///  * [Navigator.initialRoute]
+  final String? initialRoute;
+
+  /// Called to generate a route for a given [RouteSettings].
+  ///
+  /// See also:
+  ///  * [Navigator.onGenerateRoute]
+  final RouteFactory? onGenerateRoute;
+
+  /// Called when [onGenerateRoute] fails to generate a route.
+  ///
+  /// See also:
+  ///  * [Navigator.onUnknownRoute]
+  final RouteFactory? onUnknownRoute;
+
   /// Returns the orientation of the [YaruMasterDetailPage] that most tightly
   /// encloses the given context.
   static Orientation orientationOf(BuildContext context) {
@@ -136,7 +168,7 @@ class YaruMasterDetailPage extends StatefulWidget {
 class _YaruMasterDetailPageState extends State<YaruMasterDetailPage> {
   double? _previousPaneWidth;
   late YaruPageController _controller;
-  final _navigatorKey = GlobalKey<NavigatorState>();
+  late final GlobalKey<NavigatorState> _navigatorKey;
 
   void _updateController() => _controller = widget.controller ??
       YaruPageController(
@@ -148,6 +180,7 @@ class _YaruMasterDetailPageState extends State<YaruMasterDetailPage> {
   void initState() {
     super.initState();
     _updateController();
+    _navigatorKey = widget.navigatorKey ?? GlobalKey<NavigatorState>();
   }
 
   @override
@@ -174,6 +207,10 @@ class _YaruMasterDetailPageState extends State<YaruMasterDetailPage> {
           : _YaruMasterDetailLayoutBuilder(
               portrait: (context) => YaruPortraitLayout(
                 navigatorKey: _navigatorKey,
+                navigatorObservers: widget.navigatorObservers,
+                initialRoute: widget.initialRoute,
+                onGenerateRoute: widget.onGenerateRoute,
+                onUnknownRoute: widget.onUnknownRoute,
                 tileBuilder: widget.tileBuilder,
                 pageBuilder: widget.pageBuilder,
                 onSelected: widget.onSelected,
@@ -183,6 +220,10 @@ class _YaruMasterDetailPageState extends State<YaruMasterDetailPage> {
               ),
               landscape: (context) => YaruLandscapeLayout(
                 navigatorKey: _navigatorKey,
+                navigatorObservers: widget.navigatorObservers,
+                initialRoute: widget.initialRoute,
+                onGenerateRoute: widget.onGenerateRoute,
+                onUnknownRoute: widget.onUnknownRoute,
                 tileBuilder: widget.tileBuilder,
                 pageBuilder: widget.pageBuilder,
                 onSelected: widget.onSelected,

--- a/lib/src/widgets/master_detail/yaru_portrait_layout.dart
+++ b/lib/src/widgets/master_detail/yaru_portrait_layout.dart
@@ -12,6 +12,10 @@ class YaruPortraitLayout extends StatefulWidget {
   const YaruPortraitLayout({
     super.key,
     required this.navigatorKey,
+    this.navigatorObservers = const <NavigatorObserver>[],
+    this.initialRoute,
+    this.onGenerateRoute,
+    this.onUnknownRoute,
     required this.tileBuilder,
     required this.pageBuilder,
     this.onSelected,
@@ -21,6 +25,10 @@ class YaruPortraitLayout extends StatefulWidget {
   });
 
   final GlobalKey<NavigatorState> navigatorKey;
+  final List<NavigatorObserver> navigatorObservers;
+  final String? initialRoute;
+  final RouteFactory? onGenerateRoute;
+  final RouteFactory? onUnknownRoute;
   final YaruMasterTileBuilder tileBuilder;
   final IndexedWidgetBuilder pageBuilder;
   final ValueChanged<int>? onSelected;
@@ -93,6 +101,9 @@ class _YaruPortraitLayoutState extends State<YaruPortraitLayout> {
         ),
         child: Navigator(
           key: widget.navigatorKey,
+          initialRoute: widget.initialRoute,
+          onGenerateRoute: widget.onGenerateRoute,
+          onUnknownRoute: widget.onUnknownRoute,
           onPopPage: (route, result) {
             _selectedIndex = -1;
             return route.didPop(result);
@@ -123,7 +134,7 @@ class _YaruPortraitLayoutState extends State<YaruPortraitLayout> {
             ),
             if (_selectedIndex != -1) page(_selectedIndex)
           ],
-          observers: [HeroController()],
+          observers: [...widget.navigatorObservers, HeroController()],
         ),
       ),
     );


### PR DESCRIPTION
To bring `YaruMasterDetailPage` on par with `YaruNavigationPage`.

See also:
- https://github.com/ubuntu/yaru_widgets.dart/pull/730
- https://github.com/ubuntu/yaru_widgets.dart/pull/731
- https://github.com/ubuntu/yaru_widgets.dart/pull/732
