### PR TITLE
feat(master-detail): allow inserting spacers and dividers

### DIFF
--- a/lib/src/widgets/master_detail/yaru_master_list_view.dart
+++ b/lib/src/widgets/master_detail/yaru_master_list_view.dart
@@ -36,24 +36,41 @@ class _YaruMasterListViewState extends State<YaruMasterListView> {
   @override
   Widget build(BuildContext context) {
     final theme = YaruMasterDetailTheme.of(context);
-    return ListView.separated(
-      separatorBuilder: (_, __) => SizedBox(height: theme.tileSpacing ?? 0),
-      padding: theme.listPadding,
+    return CustomScrollView(
       controller: _controller,
-      itemCount: widget.length,
-      itemBuilder: (context, index) => YaruMasterTileScope(
-        index: index,
-        selected: index == widget.selectedIndex,
-        onTap: () => widget.onTap(index),
-        child: Builder(
-          builder: (context) => widget.builder(
-            context,
-            index,
-            index == widget.selectedIndex,
-            widget.availableWidth,
+      slivers: [
+        SliverFillRemaining(
+          hasScrollBody: false,
+          child: Padding(
+            padding: theme.listPadding ?? EdgeInsets.zero,
+            child: Column(
+              children: List.generate(
+                widget.length,
+                (index) => YaruMasterTileScope(
+                  index: index,
+                  selected: index == widget.selectedIndex,
+                  onTap: () => widget.onTap(index),
+                  child: Builder(
+                    builder: (context) => widget.builder(
+                      context,
+                      index,
+                      index == widget.selectedIndex,
+                      widget.availableWidth,
+                    ),
+                  ),
+                ),
+              ).withSpacing(theme.tileSpacing ?? 0),
+            ),
           ),
         ),
-      ),
+      ],
     );
   }
+}
+
+extension on List<Widget> {
+  List<Widget> withSpacing(double height) => expand((item) sync* {
+        yield SizedBox(height: height);
+        yield item;
+      }).skip(1).toList();
 }


### PR DESCRIPTION
A separate bottom bar works fine for about or settings dialogs and similar, but gets clumsy if one wants to have normal master tiles at the bottom. This PR makes it possible for `YaruMasterDetailPage.tileBuilder` to return spacers (and dividers) to make it possible to categorize master list items in any way desired.

![image](https://github.com/ubuntu/yaru_widgets.dart/assets/140617/63e3f74e-548c-429f-9bb3-0e7599506fb6)

```dart
final pages = <({WidgetBuilder tile, WidgetBuilder page})>[
  (
    tile: (_) => const YaruMasterTile(title: Text('Foo')),
    page: (_) => const Center(child: Text('Foo')),
  ),
  (
    tile: (_) => const YaruMasterTile(title: Text('Bar')),
    page: (_) => const Center(child: Text('Bar')),
  ),
  (
    tile: (_) => const YaruMasterTile(title: Text('Baz')),
    page: (_) => const Center(child: Text('Baz')),
  ),
  (
    tile: (_) => const YaruMasterTile(title: Text('Qux')),
    page: (_) => const Center(child: Text('Qux')),
  ),
  (
    tile: (_) => const Spacer(),
    page: (_) => const SizedBox.shrink(),
  ),
  (
    tile: (_) => const Divider(height: 1),
    page: (_) => const SizedBox.shrink(),
  ),
  (
    tile: (_) => const YaruMasterTile(title: Text('Manage')),
    page: (_) => const Center(child: Text('Manage')),
  ),
  (
    tile: (_) => const YaruMasterTile(title: Text('About')),
    page: (_) => const Center(child: Text('About')),
  ),
];

return Scaffold(
  appBar: const YaruWindowTitleBar(title: Text('YaruMasterDetailPage')),
  body: YaruMasterDetailPage(
    length: pages.length,
    tileBuilder: (context, index, selected, availableWidth) =>
        pages[index].tile(context),
    pageBuilder: (context, index) => pages[index].page(context),
  ),
);
```