### PR TITLE
fix(YaruMasterTile): let onTap override scope ontap

### DIFF
--- a/lib/src/widgets/master_detail/yaru_master_tile.dart
+++ b/lib/src/widgets/master_detail/yaru_master_tile.dart
@@ -35,13 +35,15 @@ class YaruMasterTile extends StatelessWidget {
   /// See [ListTile.trailing].
   final Widget? trailing;
 
-  /// See [ListTile.onTap].
+  /// An optional [VoidCallback] forwarded to the internal [ListTile]
+  /// If not provided [YaruMasterTileScope] `onTap` will be called.
   final VoidCallback? onTap;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final scope = YaruMasterTileScope.maybeOf(context);
+
     final isSelected = selected ?? scope?.selected ?? false;
     final scrollbarThicknessWithTrack =
         _calcScrollbarThicknessWithTrack(context);
@@ -76,8 +78,11 @@ class YaruMasterTile extends StatelessWidget {
           trailing: trailing,
           selected: isSelected,
           onTap: () {
-            scope?.onTap();
-            onTap?.call();
+            if (onTap != null) {
+              onTap!.call();
+            } else {
+              scope?.onTap();
+            }
           },
         ),
       ),


### PR DESCRIPTION
~~This adds a parameter to disable looking up the YaruMasterTileScope for tiles added to the list inside YMD that should not open a page.~~

~~Is this the correct approach @jpnurmi ?~~

Use case: 1 tile inside the list should open a dialog and not select/load a page

Closes #718
