### PR TITLE
fix(YaruTitleBar): foreground color is not forwarded to YaruTitleBar

### DIFF
--- a/lib/src/widgets/yaru_title_bar.dart
+++ b/lib/src/widgets/yaru_title_bar.dart
@@ -510,6 +510,7 @@ class YaruWindowTitleBar extends StatelessWidget
           centerTitle: centerTitle,
           titleSpacing: titleSpacing,
           backgroundColor: backgroundColor,
+          foregroundColor: foregroundColor,
           shape: shape,
           border: border,
           style: style,


### PR DESCRIPTION
Fixes #757

<!-- REMINDER:

1) For a bug fix, please target the `release` branch, else target `main`.

2) If this PR introduces any visual changes, please run:
```
flutter test --update-goldens
```
and commit the changes **or** if not covered by tests, attach screenshots below:

|       | Before | After |
|-------|--------|-------|
| Light |        |       |
| Dark  |        |       |

-->
