### PR TITLE
fix(YaruWindowControl): colors are not exposed

### DIFF
--- a/lib/src/widgets/yaru_title_bar.dart
+++ b/lib/src/widgets/yaru_title_bar.dart
@@ -235,6 +235,8 @@ class YaruTitleBar extends StatelessWidget implements PreferredSizeWidget {
                           children: [
                             if (isMinimizable == true)
                               YaruWindowControl(
+                                foregroundColor: foregroundColor,
+                                backgroundColor: backgroundColor,
                                 type: YaruWindowControlType.minimize,
                                 onTap: onMinimize != null
                                     ? () => onMinimize!(context)
@@ -242,6 +244,8 @@ class YaruTitleBar extends StatelessWidget implements PreferredSizeWidget {
                               ),
                             if (isRestorable == true)
                               YaruWindowControl(
+                                foregroundColor: foregroundColor,
+                                backgroundColor: backgroundColor,
                                 type: YaruWindowControlType.restore,
                                 onTap: onRestore != null
                                     ? () => onRestore!(context)
@@ -249,6 +253,8 @@ class YaruTitleBar extends StatelessWidget implements PreferredSizeWidget {
                               ),
                             if (isMaximizable == true)
                               YaruWindowControl(
+                                foregroundColor: foregroundColor,
+                                backgroundColor: backgroundColor,
                                 type: YaruWindowControlType.maximize,
                                 onTap: onMaximize != null
                                     ? () => onMaximize!(context)
@@ -256,6 +262,8 @@ class YaruTitleBar extends StatelessWidget implements PreferredSizeWidget {
                               ),
                             if (isClosable == true)
                               YaruWindowControl(
+                                foregroundColor: foregroundColor,
+                                backgroundColor: backgroundColor,
                                 type: YaruWindowControlType.close,
                                 onTap: onClose != null
                                     ? () => onClose!(context)

--- a/lib/src/widgets/yaru_window_control.dart
+++ b/lib/src/widgets/yaru_window_control.dart
@@ -28,11 +28,17 @@ class YaruWindowControl extends StatefulWidget {
     super.key,
     required this.type,
     required this.onTap,
+    this.foregroundColor,
+    this.backgroundColor,
   });
 
   final YaruWindowControlType type;
 
   final GestureTapCallback? onTap;
+
+  final Color? foregroundColor;
+
+  final Color? backgroundColor;
 
   @override
   State<YaruWindowControl> createState() {
@@ -113,7 +119,7 @@ class _YaruWindowControlState extends State<YaruWindowControl>
     });
   }
 
-  Color _getColor(BuildContext context) {
+  Color _getColor(BuildContext context, [Color? color]) {
     final onSurface = Theme.of(context).colorScheme.onSurface;
 
     if (!interactive) {
@@ -148,7 +154,7 @@ class _YaruWindowControlState extends State<YaruWindowControl>
         child: AnimatedContainer(
           duration: _kWindowControlBackgroundAnimationDuration,
           decoration: BoxDecoration(
-            color: _getColor(context),
+            color: _getColor(context, widget.backgroundColor),
             border: colorScheme.isHighContrast
                 ? Border.all(
                     color: colorScheme.outlineVariant,
@@ -167,7 +173,8 @@ class _YaruWindowControlState extends State<YaruWindowControl>
                   painter: _YaruWindowControlPainter(
                     type: widget.type,
                     oldType: oldType,
-                    iconColor: Theme.of(context).colorScheme.onSurface,
+                    iconColor: widget.foregroundColor ??
+                        Theme.of(context).colorScheme.onSurface,
                     position: _position.value,
                     interactive: interactive,
                   ),


### PR DESCRIPTION

![grafik](https://github.com/ubuntu/yaru_widgets.dart/assets/15329494/e7f3ea2e-8269-4a32-a893-6e0da3ebb703)



Fixes #759

<!-- REMINDER:

1) For a bug fix, please target the `release` branch, else target `main`.

2) If this PR introduces any visual changes, please run:
```
flutter test --update-goldens
```
and commit the changes **or** if not covered by tests, attach screenshots below:

|       | Before | After |
|-------|--------|-------|
| Light |        |       |
| Dark  |        |       |

-->
