### PR TITLE
fix(YaruWindowControl): use foreground color for disk background

### DIFF
--- a/lib/src/widgets/yaru_window_control.dart
+++ b/lib/src/widgets/yaru_window_control.dart
@@ -120,7 +120,7 @@ class _YaruWindowControlState extends State<YaruWindowControl>
   }
 
   Color _getColor(BuildContext context, [Color? color]) {
-    final onSurface = Theme.of(context).colorScheme.onSurface;
+    final onSurface = color ?? Theme.of(context).colorScheme.onSurface;
 
     if (!interactive) {
       return onSurface.withOpacity(_kWindowControlBackgroundOpacityDisabled);
@@ -154,7 +154,7 @@ class _YaruWindowControlState extends State<YaruWindowControl>
         child: AnimatedContainer(
           duration: _kWindowControlBackgroundAnimationDuration,
           decoration: BoxDecoration(
-            color: _getColor(context, widget.backgroundColor),
+            color: _getColor(context, widget.foregroundColor),
             border: colorScheme.isHighContrast
                 ? Border.all(
                     color: colorScheme.outlineVariant,


### PR DESCRIPTION
![grafik](https://github.com/ubuntu/yaru_widgets.dart/assets/15329494/3ab75094-9941-4185-bb33-74f48e6eec50)

![grafik](https://github.com/ubuntu/yaru_widgets.dart/assets/15329494/35e97b00-813d-4a9f-ac04-3b0b39c1d43b)

sorry, now it works ^^