### PR TITLE
fix: adjust search icon size

### DIFF
--- a/lib/src/widgets/yaru_search_field.dart
+++ b/lib/src/widgets/yaru_search_field.dart
@@ -386,13 +386,14 @@ class YaruSearchButton extends StatelessWidget {
                 YaruIcons.search,
                 // Note: Center is needed for when the button is leading
                 // This increases the iconsize, thus this adjustment is needed
-                size: kYaruIconSize - 2,
+                //
+                size: kYaruIconSize - 4,
                 color: theme.colorScheme.onSurface,
               ),
           icon: icon ??
               Icon(
                 YaruIcons.search,
-                size: kYaruIconSize - 2,
+                size: kYaruIconSize - 4,
                 color: theme.colorScheme.onSurface,
               ),
           onPressed: onPressed,


### PR DESCRIPTION
before 
![grafik](https://github.com/ubuntu/yaru_widgets.dart/assets/15329494/022a297f-5a16-46a9-bc9c-e3673cfd7730)

after
![grafik](https://github.com/ubuntu/yaru_widgets.dart/assets/15329494/d8d2ccb4-130c-4bc6-b3f8-c4c62d1ca7f2)
