### PR TITLE
fix: overflow in left pane of `YaruMasterDetailPage`

### DIFF
--- a/lib/src/widgets/master_detail/yaru_master_list_view.dart
+++ b/lib/src/widgets/master_detail/yaru_master_list_view.dart
@@ -25,45 +25,31 @@ class YaruMasterListView extends StatefulWidget {
 }
 
 class _YaruMasterListViewState extends State<YaruMasterListView> {
-  final _controller = ScrollController();
-
-  @override
-  void dispose() {
-    _controller.dispose();
-    super.dispose();
-  }
-
   @override
   Widget build(BuildContext context) {
     final theme = YaruMasterDetailTheme.of(context);
-    return CustomScrollView(
-      controller: _controller,
-      slivers: [
-        SliverFillRemaining(
-          hasScrollBody: false,
-          child: Padding(
-            padding: theme.listPadding ?? EdgeInsets.zero,
-            child: Column(
-              children: List.generate(
-                widget.length,
-                (index) => YaruMasterTileScope(
-                  index: index,
-                  selected: index == widget.selectedIndex,
-                  onTap: () => widget.onTap(index),
-                  child: Builder(
-                    builder: (context) => widget.builder(
-                      context,
-                      index,
-                      index == widget.selectedIndex,
-                      widget.availableWidth,
-                    ),
-                  ),
+    return SingleChildScrollView(
+      child: Padding(
+        padding: theme.listPadding ?? EdgeInsets.zero,
+        child: Column(
+          children: List.generate(
+            widget.length,
+            (index) => YaruMasterTileScope(
+              index: index,
+              selected: index == widget.selectedIndex,
+              onTap: () => widget.onTap(index),
+              child: Builder(
+                builder: (context) => widget.builder(
+                  context,
+                  index,
+                  index == widget.selectedIndex,
+                  widget.availableWidth,
                 ),
-              ).withSpacing(theme.tileSpacing ?? 0),
+              ),
             ),
-          ),
+          ).withSpacing(theme.tileSpacing ?? 0),
         ),
-      ],
+      ),
     );
   }
 }


### PR DESCRIPTION
No visual change.
It looks like the problem comes from both `SliverFillRemaining` and `ListTile` which seems to not send its correct height when having a subtitle. I will investigate deeper because it looks like a bug.

@d-loose I will create a backport PR for 2.7, so you can get the fix before migrating to 3.2

Fixes #785
