### PR TITLE
fix(YaruExpansionPanel): use hairline dividers

### DIFF
--- a/lib/src/widgets/yaru_expansion_panel.dart
+++ b/lib/src/widgets/yaru_expansion_panel.dart
@@ -85,9 +85,7 @@ class _YaruExpansionPanelState extends State<YaruExpansionPanel> {
                 if (index != widget.children.length - 1 && widget.placeDividers)
                   const Padding(
                     padding: EdgeInsets.symmetric(vertical: 1),
-                    child: Divider(
-                      height: 0.0,
-                    ),
+                    child: Divider(),
                   ),
               ],
             ),


### PR DESCRIPTION


|       | Before | After |
|-------|--------|-------|
| Light |![grafik](https://github.com/ubuntu/yaru_widgets.dart/assets/15329494/04fb5c22-4bab-4c44-aa80-2856955ff560)|![grafik](https://github.com/ubuntu/yaru_widgets.dart/assets/15329494/60336aac-0f28-44d7-97e1-cb185fe43c1e)|



