### PR TITLE
feat(YaruChoiceChipBar): add selectedFirst parameter

### DIFF
--- a/example/lib/pages/choice_chip_bar_page.dart
+++ b/example/lib/pages/choice_chip_bar_page.dart
@@ -29,6 +29,7 @@ class _ChoiceChipBarPageState extends State<ChoiceChipBarPage> {
         child: Column(
           children: [
             YaruChoiceChipBar(
+              selectedFirst: false,
               showCheckMarks: false,
               shrinkWrap: true,
               clearOnSelect: false,

--- a/lib/src/widgets/yaru_choice_chip_bar.dart
+++ b/lib/src/widgets/yaru_choice_chip_bar.dart
@@ -29,6 +29,7 @@ class YaruChoiceChipBar extends StatefulWidget {
     this.clearOnSelect = true,
     this.shrinkWrap = true,
     this.showCheckMarks = true,
+    this.selectedFirst = true,
   }) : assert(labels.length == isSelected.length);
 
   /// The [List] of [Widget]'s used to generate a [List] of [ChoiceChip]s
@@ -113,6 +114,9 @@ class YaruChoiceChipBar extends StatefulWidget {
   /// The default is `true`.
   final bool showCheckMarks;
 
+  /// Defines if the selected [ChoiceChip]s should be always placed first.
+  final bool selectedFirst;
+
   @override
   State<YaruChoiceChipBar> createState() => _YaruChoiceChipBarState();
 }
@@ -187,12 +191,17 @@ class _YaruChoiceChipBarState extends State<YaruChoiceChipBar> {
       );
     }
 
-    final children = [
-      for (int index = 0; index < widget.labels.length; index++)
-        if (widget.isSelected[index]) themedChip(index),
-      for (int index = 0; index < widget.labels.length; index++)
-        if (!widget.isSelected[index]) themedChip(index),
-    ];
+    final children = widget.selectedFirst
+        ? [
+            for (int index = 0; index < widget.labels.length; index++)
+              if (widget.isSelected[index]) themedChip(index),
+            for (int index = 0; index < widget.labels.length; index++)
+              if (!widget.isSelected[index]) themedChip(index),
+          ]
+        : [
+            for (int index = 0; index < widget.labels.length; index++)
+              themedChip(index),
+          ];
 
     final listView = ListView(
       shrinkWrap: widget.shrinkWrap,


### PR DESCRIPTION
<img width="969" alt="Bildschirmfoto 2024-01-11 um 10 55 42" src="https://github.com/ubuntu/yaru_widgets.dart/assets/15329494/090fee3d-7d01-44c0-aca8-0afc678c3c88">

@Jupi007 this adds an option if you do not want the selected chips to be shown first
default stays the same in lib